### PR TITLE
feat(db): migration 0003 — habits + habit_logs schema

### DIFF
--- a/src/core/database/schema/habit-logs.schema.ts
+++ b/src/core/database/schema/habit-logs.schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, date, boolean, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, date, boolean, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 import { habits } from "./habits.schema.js";
 
 export const habitLogs = pgTable(
@@ -12,10 +12,7 @@ export const habitLogs = pgTable(
     completed: boolean("completed").notNull().default(false),
     completedAt: timestamp("completed_at", { withTimezone: true, mode: "date" }),
   },
-  (table) => [
-    uniqueIndex("uq_habit_log").on(table.habitId, table.logDate),
-    index("idx_habit_logs_habit").on(table.habitId),
-  ]
+  (table) => [uniqueIndex("uq_habit_log").on(table.habitId, table.logDate)]
 );
 
 export type HabitLog = typeof habitLogs.$inferSelect;

--- a/src/core/database/schema/habits.schema.ts
+++ b/src/core/database/schema/habits.schema.ts
@@ -7,28 +7,40 @@ import {
   date,
   timestamp,
   jsonb,
+  index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { users } from "./users.schema.js";
 
-export const habits = pgTable("habits", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: uuid("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  name: varchar("name", { length: 255 }).notNull(),
-  targetSkill: varchar("target_skill", { length: 100 }),
-  icon: varchar("icon", { length: 50 }).notNull(),
-  color: varchar("color", { length: 20 }).notNull(),
-  frequency: varchar("frequency", { length: 20 }).notNull().default("daily"),
-  targetDays: integer("target_days").notNull().default(7),
-  isActive: boolean("is_active").notNull().default(true),
-  sortOrder: integer("sort_order").notNull().default(0),
-  startDate: date("start_date"),
-  habitPlan: jsonb("habit_plan").notNull().default({}),
-  planStatus: varchar("plan_status", { length: 20 }).notNull().default("active"),
-  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
-});
+export const habits = pgTable(
+  "habits",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    targetSkill: varchar("target_skill", { length: 100 }),
+    icon: varchar("icon", { length: 50 }).notNull(),
+    color: varchar("color", { length: 20 }).notNull(),
+    frequency: varchar("frequency", { length: 20 }).notNull().default("daily"),
+    targetDays: integer("target_days").notNull().default(7),
+    isActive: boolean("is_active").notNull().default(true),
+    sortOrder: integer("sort_order").notNull().default(0),
+    startDate: date("start_date"),
+    habitPlan: jsonb("habit_plan").notNull().default({}),
+    planStatus: varchar("plan_status", { length: 20 }).notNull().default("active"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_habits_user_id").on(table.userId),
+    index("idx_habits_user_active")
+      .on(table.userId)
+      .where(sql`${table.isActive} = TRUE`),
+    index("idx_habit_plan_gin").using("gin", table.habitPlan),
+  ]
+);
 
 export type Habit = typeof habits.$inferSelect;
 export type NewHabit = typeof habits.$inferInsert;

--- a/src/migrations/0003_habits_and_habit_logs.sql
+++ b/src/migrations/0003_habits_and_habit_logs.sql
@@ -39,13 +39,11 @@ CREATE TABLE "habit_logs" (
 );
 
 -- Step 6: Create unique index on habit_id + log_date
+-- Note: uq_habit_log also covers queries by habit_id alone (leftmost prefix),
+-- so a separate idx_habit_logs_habit index is redundant
 CREATE UNIQUE INDEX "uq_habit_log" ON "habit_logs"("habit_id", "log_date");
 
--- Step 7: Add index on habit_id for habit_logs queries
-CREATE INDEX "idx_habit_logs_habit" ON "habit_logs"("habit_id");
-
 -- Rollback section (run in reverse order if needed)
--- DROP INDEX IF EXISTS "idx_habit_logs_habit";
 -- DROP INDEX IF EXISTS "uq_habit_log";
 -- DROP TABLE IF EXISTS "habit_logs";
 -- DROP INDEX IF EXISTS "idx_habit_plan_gin";


### PR DESCRIPTION
## Summary

- Adiciona migration `0003_habits_and_habit_logs.sql` com tabelas `habits` e `habit_logs`
- Schema Drizzle para `habits` (userId FK, name, icon, color, frequency, targetDays, isActive, sortOrder, habitPlan JSONB, planStatus, timestamps)
- Schema Drizzle para `habit_logs` (habitId FK, logDate, completed, completedAt) com unique index em `(habit_id, log_date)`
- Índices: `idx_habits_user_id`, `idx_habits_user_active` (parcial), `idx_habit_plan_gin` (GIN/JSONB), `idx_habit_logs_habit`

Closes #42

## Test plan
- [ ] `npm run db:migrate` aplica a migration sem erros
- [ ] Drizzle Studio mostra as tabelas com os tipos corretos
- [ ] Rollback comentado na migration para referência

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Suporte a hábitos e registro diário de hábitos, com acompanhamento de conclusão e horário.
* **Chores**
  * Infraestrutura de banco de dados adicionada para armazenar hábitos e registros, com índices e regras de integridade para garantir desempenho e consistência.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->