### PR TITLE
feat(habits): GET /habits + GET /habits/:id — read endpoints

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 import { env } from "./core/config/env.js";
 import { prettyTransport } from "./core/config/logger.js";
 import { authRoutes } from "./modules/auth/auth.routes.js";
+import { habitsRoutes } from "./modules/habits/habits.routes.js";
 import { healthRoutes } from "./modules/health/health.routes.js";
 import { usersRoutes } from "./modules/users/users.routes.js";
 import {
@@ -26,6 +27,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(healthRoutes);
   await fastify.register(authRoutes);
   await fastify.register(usersRoutes);
+  await fastify.register(habitsRoutes);
 
   return fastify;
 }

--- a/src/modules/habits/habits.controller.ts
+++ b/src/modules/habits/habits.controller.ts
@@ -1,0 +1,86 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { HabitsService } from "./habits.service.js";
+import {
+  createHabitSchema,
+  updateHabitSchema,
+  checkInSchema,
+  type CreateHabitInput,
+  type UpdateHabitInput,
+  type CheckInInput,
+} from "./habits.types.js";
+import { handleControllerError } from "../../shared/utils/http.js";
+
+export function createHabitsController(service: HabitsService) {
+  return {
+    async list(request: FastifyRequest, reply: FastifyReply) {
+      try {
+        const { id } = request.user;
+        const habits = await service.list(id);
+        return reply.code(200).send(habits);
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+
+    async getById(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) {
+      try {
+        const { id: userId } = request.user;
+        const habit = await service.getById(userId, request.params.id);
+        return reply.code(200).send(habit);
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+
+    async create(request: FastifyRequest<{ Body: CreateHabitInput }>, reply: FastifyReply) {
+      try {
+        const { id: userId } = request.user;
+        const data = createHabitSchema.parse(request.body);
+        const habit = await service.create(userId, data);
+        return reply.code(201).send(habit);
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+
+    async update(
+      request: FastifyRequest<{ Params: { id: string }; Body: UpdateHabitInput }>,
+      reply: FastifyReply
+    ) {
+      try {
+        const { id: userId } = request.user;
+        const data = updateHabitSchema.parse(request.body);
+        const habit = await service.update(userId, request.params.id, data);
+        return reply.code(200).send(habit);
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+
+    async remove(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) {
+      try {
+        const { id: userId } = request.user;
+        await service.remove(userId, request.params.id);
+        return reply.code(204).send();
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+
+    async checkIn(
+      request: FastifyRequest<{ Params: { id: string }; Body: CheckInInput }>,
+      reply: FastifyReply
+    ) {
+      try {
+        const { id: userId } = request.user;
+        const data = checkInSchema.parse(request.body);
+        const log = await service.checkIn(userId, request.params.id, data);
+        return reply.code(200).send(log);
+      } catch (error) {
+        return handleControllerError(error, reply);
+      }
+    },
+  };
+}
+
+export type HabitsController = ReturnType<typeof createHabitsController>;

--- a/src/modules/habits/habits.module.ts
+++ b/src/modules/habits/habits.module.ts
@@ -1,0 +1,12 @@
+import type { DrizzleDb } from "../../core/database/connection.js";
+import { createHabitsRepository } from "./habits.repository.js";
+import { createHabitLogsRepository } from "./habit-logs.repository.js";
+import { createHabitsService } from "./habits.service.js";
+import { createHabitsController } from "./habits.controller.js";
+
+export function createHabitsModule(db: DrizzleDb) {
+  const habitsRepo = createHabitsRepository(db);
+  const habitLogsRepo = createHabitLogsRepository(db);
+  const service = createHabitsService({ habitsRepo, habitLogsRepo });
+  return { controller: createHabitsController(service) };
+}

--- a/src/modules/habits/habits.routes.ts
+++ b/src/modules/habits/habits.routes.ts
@@ -1,0 +1,93 @@
+import type { FastifyInstance } from "fastify";
+import { getDb } from "../../core/database/connection.js";
+import { authenticate } from "../../core/hooks/authenticate.js";
+import { createHabitsModule } from "./habits.module.js";
+import { ALLOWED_FREQUENCIES } from "./habits.types.js";
+
+const habitSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "id",
+    "userId",
+    "name",
+    "icon",
+    "color",
+    "frequency",
+    "targetDays",
+    "isActive",
+    "sortOrder",
+    "habitPlan",
+    "planStatus",
+    "createdAt",
+    "updatedAt",
+  ],
+  properties: {
+    id: { type: "string", format: "uuid" },
+    userId: { type: "string", format: "uuid" },
+    name: { type: "string" },
+    targetSkill: { anyOf: [{ type: "string" }, { type: "null" }] },
+    icon: { type: "string" },
+    color: { type: "string" },
+    frequency: { type: "string", enum: [...ALLOWED_FREQUENCIES] },
+    targetDays: { type: "integer" },
+    isActive: { type: "boolean" },
+    sortOrder: { type: "integer" },
+    startDate: { anyOf: [{ type: "string" }, { type: "null" }] },
+    habitPlan: { type: "object" },
+    planStatus: { type: "string" },
+    createdAt: { type: "string" },
+    updatedAt: { type: "string" },
+  },
+};
+
+const errorResponse = (description: string) => ({
+  description,
+  type: "object",
+  properties: { error: { type: "string" } },
+});
+
+export async function habitsRoutes(fastify: FastifyInstance) {
+  const { controller } = createHabitsModule(getDb());
+
+  fastify.get("/habits", {
+    schema: {
+      description: "List all habits for the authenticated user",
+      tags: ["Habits"],
+      summary: "List habits",
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: {
+          description: "Habits retrieved successfully",
+          type: "array",
+          items: habitSchema,
+        },
+        401: errorResponse("Unauthorized"),
+      },
+    },
+    preHandler: authenticate,
+    handler: controller.list,
+  });
+
+  fastify.get("/habits/:id", {
+    schema: {
+      description: "Get a specific habit by ID",
+      tags: ["Habits"],
+      summary: "Get habit",
+      security: [{ bearerAuth: [] }],
+      params: {
+        type: "object",
+        properties: { id: { type: "string", format: "uuid" } },
+        required: ["id"],
+      },
+      response: {
+        200: { description: "Habit retrieved successfully", ...habitSchema },
+        401: errorResponse("Unauthorized"),
+        403: errorResponse("Access denied"),
+        404: errorResponse("Habit not found"),
+      },
+    },
+    preHandler: authenticate,
+    handler: controller.getById,
+  });
+}


### PR DESCRIPTION
## Summary

- `habits.controller.ts`: controller completo (list, getById, create, update, remove, checkIn)
- `habits.module.ts`: factory montando repo → service → controller
- `habits.routes.ts`: registra `GET /habits` e `GET /habits/:id` com Swagger + `preHandler: authenticate`
- `app.ts`: registra `habitsRoutes`

Closes #45

## Test plan
- [ ] `GET /habits` retorna 200 com array (vazio ou com habits do user)
- [ ] `GET /habits/:id` retorna 200 para habit do user, 403 para habit de outro user, 404 para id inexistente
- [ ] Todos os testes existentes continuam passando