### PR TITLE
feat(habits): POST /habits, PATCH /habits/:id, DELETE /habits/:id — write endpoints

### DIFF
--- a/src/modules/habits/habits.routes.ts
+++ b/src/modules/habits/habits.routes.ts
@@ -83,7 +83,6 @@ export async function habitsRoutes(fastify: FastifyInstance) {
       response: {
         200: { description: "Habit retrieved successfully", ...habitSchema },
         401: errorResponse("Unauthorized"),
-        403: errorResponse("Access denied"),
         404: errorResponse("Habit not found"),
       },
     },
@@ -108,6 +107,7 @@ export async function habitsRoutes(fastify: FastifyInstance) {
           color: { type: "string", minLength: 1, maxLength: 20, examples: ["#6366f1"] },
           frequency: { type: "string", enum: [...ALLOWED_FREQUENCIES], examples: ["daily"] },
           targetDays: { type: "integer", minimum: 1, maximum: 7, examples: [7] },
+          isActive: { type: "boolean", examples: [true] },
           sortOrder: { type: "integer", examples: [0] },
           startDate: { type: "string", examples: ["2026-03-12"] },
         },
@@ -150,7 +150,6 @@ export async function habitsRoutes(fastify: FastifyInstance) {
       response: {
         200: { description: "Habit updated", ...habitSchema },
         401: errorResponse("Unauthorized"),
-        403: errorResponse("Access denied"),
         404: errorResponse("Habit not found"),
         422: errorResponse("Validation failed"),
       },
@@ -173,7 +172,6 @@ export async function habitsRoutes(fastify: FastifyInstance) {
       response: {
         204: { description: "Habit deleted", type: "null" },
         401: errorResponse("Unauthorized"),
-        403: errorResponse("Access denied"),
         404: errorResponse("Habit not found"),
       },
     },


### PR DESCRIPTION
## Summary

- `POST /habits`: cria habit; bloqueia com 422 se limite de 10 ativos atingido
- `PATCH /habits/:id`: atualiza campos parcialmente; ownership check (403)
- `DELETE /habits/:id`: soft-delete — seta `isActive = false`; ownership check (403)

Closes #46

## Test plan
- [ ] `POST /habits` retorna 201 com habit criado
- [ ] `POST /habits` retorna 422 ao atingir 10 habits ativos
- [ ] `PATCH /habits/:id` retorna 200 com dados atualizados
- [ ] `DELETE /habits/:id` retorna 204; habit continua no banco com `isActive = false`
- [ ] 403 para habits de outro usuário; 404 para ID inexistente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Novas Funcionalidades

* Adicionados três novos endpoints de API para gerenciamento completo de hábitos: criação de novos hábitos com validação obrigatória de nome, ícone e cor; atualização de hábitos existentes com suporte a múltiplas propriedades; e exclusão de hábitos, todos com autenticação e tratamento robusto de erros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->