### PR TITLE
fix: remove homolog deploy from CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,13 +23,17 @@ jobs:
         run: |
           echo "Triggering Render deploy for production"
 
-          RESPONSE=$(curl -sS -o /dev/null -w "%{http_code}" \
+          BODY=$(curl -sS -w "\n%{http_code}" \
             --max-time 30 \
             -X POST "${{ secrets.RENDER_DEPLOY_HOOK_PROD }}")
+
+          RESPONSE=$(echo "$BODY" | tail -1)
+          CONTENT=$(echo "$BODY" | head -n -1)
 
           if [ "$RESPONSE" = "200" ] || [ "$RESPONSE" = "201" ]; then
             echo "Deploy triggered successfully (HTTP $RESPONSE)"
           else
             echo "Failed to trigger deploy (HTTP $RESPONSE)"
+            echo "Response body: $CONTENT"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Removed `develop` from CD trigger — homolog service was deleted
- CD now only deploys on `main` push to production (Render)
- Simplified workflow: no more branch conditionals, always uses `RENDER_DEPLOY_HOOK_PROD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Melhorado a confiabilidade das implantações em produção através da simplificação do fluxo de deployment automatizado e implementação de tratamento robusto de erros. O sistema agora opera exclusivamente no ambiente de produção, com detecção explícita e reporte automático de falhas. Isso garante maior confiabilidade, transparência e agilidade nas entregas de novas versões.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->