### PR TITLE
feat(ai-agents): implement Language Teacher agent

### DIFF
--- a/src/modules/ai-agents/agent-language.ts
+++ b/src/modules/ai-agents/agent-language.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const languageAgentErrorSchema = z.object({
+  original: z.string(),
+  corrected: z.string(),
+  explanation: z.string(),
+});
+
+export const languageAgentLinguisticSchema = z.object({
+  grammarScore: z.number().min(0).max(100),
+  vocabularyScore: z.number().min(0).max(100),
+  fluencyScore: z.number().min(0).max(100),
+});
+
+export const languageAgentResponseSchema = z.object({
+  agentType: z.literal("language-teacher"),
+  targetSkill: z.string(),
+  linguistic: languageAgentLinguisticSchema,
+  errors: z.array(languageAgentErrorSchema),
+  modelSentence: z.string(),
+  nextChallenge: z.string(),
+});
+
+export type LanguageAgentResponse = z.infer<typeof languageAgentResponseSchema>;
+export type LanguageAgentError = z.infer<typeof languageAgentErrorSchema>;
+export type LanguageAgentLinguistic = z.infer<typeof languageAgentLinguisticSchema>;
+
+export type LanguageAgentInput = {
+  targetSkill: string;
+  uiLanguage: string;
+  journalContent: string;
+};
+
+function langInstruction(uiLanguage: string): string {
+  return `IMPORTANT: Write ALL text fields in the language with code "${uiLanguage}".`;
+}
+
+export function buildLanguageAgentPrompt(input: LanguageAgentInput): string {
+  return `You are a Language Teacher AI agent specialized in language learning analysis.
+${langInstruction(input.uiLanguage)}
+
+Target language: ${input.targetSkill}
+User's journal entry: "${input.journalContent}"
+
+Analyze the journal entry and provide feedback. Return ONLY valid JSON:
+{
+  "agentType": "language-teacher",
+  "targetSkill": "${input.targetSkill}",
+  "linguistic": {
+    "grammarScore": 0-100,
+    "vocabularyScore": 0-100,
+    "fluencyScore": 0-100
+  },
+  "errors": [
+    { "original": "incorrect phrase", "corrected": "correct phrase", "explanation": "brief explanation" }
+  ],
+  "modelSentence": "example sentence in ${input.targetSkill}",
+  "nextChallenge": "personalized next challenge for the user"
+}
+
+IMPORTANT: Output must be complete, valid JSON only. No markdown.`;
+}

--- a/src/modules/ai-agents/language-agent.service.ts
+++ b/src/modules/ai-agents/language-agent.service.ts
@@ -1,0 +1,123 @@
+import { env } from "../../core/config/env.js";
+import { logger } from "../../core/config/logger.js";
+import {
+  languageAgentResponseSchema,
+  buildLanguageAgentPrompt,
+  type LanguageAgentInput,
+  type LanguageAgentResponse,
+} from "./agent-language.js";
+
+const GEMINI_API_URL =
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
+
+const GEMINI_TIMEOUT_MS = 30_000;
+const GEMINI_MAX_RETRIES = 3;
+const GEMINI_RETRY_BASE_MS = 5_000;
+
+class GeminiRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GeminiRateLimitError";
+  }
+}
+
+async function callGeminiOnce(
+  apiKey: string,
+  prompt: string,
+  maxOutputTokens: number
+): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GEMINI_TIMEOUT_MS);
+
+  const response = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    signal: controller.signal,
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens,
+        responseMimeType: "application/json",
+      },
+    }),
+  });
+
+  clearTimeout(timeout);
+
+  if (response.status === 429) {
+    throw new GeminiRateLimitError("Gemini rate limit exceeded");
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  };
+
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) throw new Error("Gemini returned empty response");
+
+  return text;
+}
+
+async function callGemini(prompt: string, maxOutputTokens: number): Promise<string> {
+  const apiKey = env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY is not configured");
+
+  for (let attempt = 0; attempt <= GEMINI_MAX_RETRIES; attempt++) {
+    try {
+      return await callGeminiOnce(apiKey, prompt, maxOutputTokens);
+    } catch (error) {
+      if (error instanceof GeminiRateLimitError && attempt < GEMINI_MAX_RETRIES) {
+        const delay = GEMINI_RETRY_BASE_MS * 2 ** attempt;
+        logger.warn(
+          `[language-agent] Rate limited, retrying in ${delay}ms (attempt ${attempt + 1}/${GEMINI_MAX_RETRIES})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("Unreachable: loop always exits via return or throw");
+}
+
+function sanitizeJsonString(text: string): string {
+  let cleaned = text.replace(/^```json\n?|\n?```$/g, "").trim();
+  cleaned = cleaned.replace(/^```\n?|\n?```$/g, "").trim();
+  cleaned = cleaned.replace(/: '([\s\S]*?)'(?=[,}\]])/g, ': "$1"');
+  cleaned = cleaned.replace(/,(\s*[}\]])/g, "$1");
+  cleaned = cleaned.replace(/"\s+/g, '" ').replace(/\s+"/g, ' "');
+  return cleaned;
+}
+
+export async function analyzeWithLanguageAgent(
+  input: LanguageAgentInput
+): Promise<LanguageAgentResponse> {
+  const prompt = buildLanguageAgentPrompt(input);
+  const rawText = await callGemini(prompt, 4096);
+
+  let parsed: unknown;
+  try {
+    const sanitized = sanitizeJsonString(rawText);
+    parsed = JSON.parse(sanitized);
+  } catch {
+    logger.error(
+      { rawTextLength: rawText.length },
+      "[language-agent] Failed to parse Gemini response"
+    );
+    throw new Error("Invalid JSON response from Gemini");
+  }
+
+  const result = languageAgentResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    logger.error({ errors: result.error.format() }, "[language-agent] Invalid response schema");
+    throw new Error("Invalid response schema from Language Agent");
+  }
+
+  return result.data;
+}

--- a/tests/unit/language-agent.test.ts
+++ b/tests/unit/language-agent.test.ts
@@ -1,0 +1,180 @@
+import {
+  buildLanguageAgentPrompt,
+  languageAgentResponseSchema,
+  languageAgentLinguisticSchema,
+  languageAgentErrorSchema,
+} from "@/modules/ai-agents/agent-language.js";
+
+describe("Language Agent", () => {
+  describe("buildLanguageAgentPrompt", () => {
+    it("builds prompt with target skill and journal content", () => {
+      const input = {
+        targetSkill: "en-US",
+        uiLanguage: "pt-BR",
+        journalContent: "Today I went to the market and bought some fruits.",
+      };
+
+      const prompt = buildLanguageAgentPrompt(input);
+
+      expect(prompt).toContain("Language Teacher AI agent");
+      expect(prompt).toContain("en-US");
+      expect(prompt).toContain("pt-BR");
+      expect(prompt).toContain("Today I went to the market and bought some fruits");
+      expect(prompt).toContain("grammarScore");
+      expect(prompt).toContain("vocabularyScore");
+      expect(prompt).toContain("fluencyScore");
+    });
+
+    it("includes model sentence field", () => {
+      const prompt = buildLanguageAgentPrompt({
+        targetSkill: "es-ES",
+        uiLanguage: "en-US",
+        journalContent: "Hola mundo",
+      });
+
+      expect(prompt).toContain("modelSentence");
+      expect(prompt).toContain("es-ES");
+    });
+
+    it("includes next challenge field", () => {
+      const prompt = buildLanguageAgentPrompt({
+        targetSkill: "fr-FR",
+        uiLanguage: "fr-FR",
+        journalContent: "Bonjour",
+      });
+
+      expect(prompt).toContain("nextChallenge");
+    });
+
+    it("outputs JSON only instruction", () => {
+      const prompt = buildLanguageAgentPrompt({
+        targetSkill: "pt-BR",
+        uiLanguage: "pt-BR",
+        journalContent: "Olá mundo",
+      });
+
+      expect(prompt).toContain("valid JSON only");
+      expect(prompt).toContain("No markdown");
+    });
+  });
+
+  describe("languageAgentLinguisticSchema", () => {
+    it("validates correct linguistic scores", () => {
+      const input = {
+        grammarScore: 85,
+        vocabularyScore: 72,
+        fluencyScore: 68,
+      };
+
+      const result = languageAgentLinguisticSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects scores below 0", () => {
+      const input = {
+        grammarScore: -1,
+        vocabularyScore: 50,
+        fluencyScore: 50,
+      };
+
+      const result = languageAgentLinguisticSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects scores above 100", () => {
+      const input = {
+        grammarScore: 101,
+        vocabularyScore: 50,
+        fluencyScore: 50,
+      };
+
+      const result = languageAgentLinguisticSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("languageAgentErrorSchema", () => {
+    it("validates correct error structure", () => {
+      const input = {
+        original: "I go to school yesterday",
+        corrected: "I went to school yesterday",
+        explanation: "Use past tense",
+      };
+
+      const result = languageAgentErrorSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects missing fields", () => {
+      const input = {
+        original: "I go to school",
+        corrected: "I went to school",
+      };
+
+      const result = languageAgentErrorSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("languageAgentResponseSchema", () => {
+    it("validates complete response", () => {
+      const input = {
+        agentType: "language-teacher",
+        targetSkill: "en-US",
+        linguistic: {
+          grammarScore: 80,
+          vocabularyScore: 75,
+          fluencyScore: 70,
+        },
+        errors: [
+          {
+            original: "I am agree",
+            corrected: "I agree",
+            explanation: "Remove redundant 'am'",
+          },
+        ],
+        modelSentence: "The weather is nice today.",
+        nextChallenge: "Practice using past tense verbs",
+      };
+
+      const result = languageAgentResponseSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid agent type", () => {
+      const input = {
+        agentType: "behavioral-coach",
+        targetSkill: "en-US",
+        linguistic: {
+          grammarScore: 80,
+          vocabularyScore: 75,
+          fluencyScore: 70,
+        },
+        errors: [],
+        modelSentence: "Test",
+        nextChallenge: "Test",
+      };
+
+      const result = languageAgentResponseSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("allows empty errors array", () => {
+      const input = {
+        agentType: "language-teacher",
+        targetSkill: "en-US",
+        linguistic: {
+          grammarScore: 100,
+          vocabularyScore: 100,
+          fluencyScore: 100,
+        },
+        errors: [],
+        modelSentence: "Perfect!",
+        nextChallenge: "Keep it up!",
+      };
+
+      const result = languageAgentResponseSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implementa o agente Language Teacher para análise de journal entries
- Especializado para linguagens (en-US, pt-BR, es-ES, fr-FR)

## Changes
- `src/modules/ai-agents/agent-language.ts` - Schemas Zod e prompt para Gemini
  - `languageAgentResponseSchema` com agentType, targetSkill, linguistic scores
  - `languageAgentLinguisticSchema` com grammarScore, vocabularyScore, fluencyScore (0-100)
  - `languageAgentErrorSchema` com original, corrected, explanation
  - `buildLanguageAgentPrompt` para gerar prompt especializado
- `src/modules/ai-agents/language-agent.service.ts` - Serviço de análise
  - Integração com Gemini API
  - Retry logic e rate limit handling
  - Validação Zod da resposta
- `tests/unit/language-agent.test.ts` - Testes unitários

## Acceptance Criteria
- [x] Prompt especializado para Language Teacher
- [x] Validação Zod da resposta
- [x] Especializado para linguagens (en-US, pt-BR, etc)
- [x] Retorna scores linguísticos (grammar, vocabulary, fluency)