### PR TITLE
feat(journal): add GET /journal/entries?date and fix migration meta

### DIFF
--- a/src/migrations/meta/0005_snapshot.json
+++ b/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,518 @@
+{
+  "id": "a7c3e891-5b2d-4f8a-9c1e-6d4b0e2f7a83",
+  "prevId": "1359b307-d492-41f1-aaad-354d55abbacf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": { "name": "email", "type": "varchar(255)", "primaryKey": false, "notNull": true },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": { "name": "name", "type": "varchar(80)", "primaryKey": false, "notNull": true },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": { "name": "user_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "ui_language": {
+          "name": "ui_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pt-BR'"
+        },
+        "bio": { "name": "bio", "type": "text", "primaryKey": false, "notNull": false },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Sao_Paulo'"
+        },
+        "ai_requests_today": {
+          "name": "ai_requests_today",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "last_ai_request": {
+          "name": "last_ai_request",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_profiles_user": {
+          "name": "idx_profiles_user",
+          "columns": [
+            { "expression": "user_id", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "btree"
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_user_id_fkey": {
+          "name": "user_profiles_user_id_fkey",
+          "tableName": "user_profiles",
+          "columns": ["user_id"],
+          "referencedTable": "users",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": { "name": "user_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableName": "refresh_tokens",
+          "columns": ["user_id"],
+          "referencedTable": "users",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.habits": {
+      "name": "habits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": { "name": "user_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "name": { "name": "name", "type": "varchar(80)", "primaryKey": false, "notNull": true },
+        "target_skill": {
+          "name": "target_skill",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": { "name": "icon", "type": "varchar(50)", "primaryKey": false, "notNull": true },
+        "color": { "name": "color", "type": "varchar(20)", "primaryKey": false, "notNull": true },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "target_days": {
+          "name": "target_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "7"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "true"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "habit_plan": {
+          "name": "habit_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "{}"
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_habits_user_id": {
+          "name": "idx_habits_user_id",
+          "columns": [
+            { "expression": "user_id", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "btree"
+        },
+        "idx_habits_user_active": {
+          "name": "idx_habits_user_active",
+          "columns": [
+            { "expression": "user_id", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "btree",
+          "where": "is_active = true"
+        },
+        "idx_habit_plan_gin": {
+          "name": "idx_habit_plan_gin",
+          "columns": [
+            { "expression": "habit_plan", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "gin"
+        }
+      },
+      "foreignKeys": {
+        "habits_user_id_fkey": {
+          "name": "habits_user_id_fkey",
+          "tableName": "habits",
+          "columns": ["user_id"],
+          "referencedTable": "users",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.habit_logs": {
+      "name": "habit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "habit_id": { "name": "habit_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "log_date": { "name": "log_date", "type": "date", "primaryKey": false, "notNull": true },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "false"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_habit_log": {
+          "name": "uq_habit_log",
+          "columns": [
+            { "expression": "habit_id", "isExpression": false, "asc": true, "nulls": "last" },
+            { "expression": "log_date", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "btree"
+        }
+      },
+      "foreignKeys": {
+        "habit_logs_habit_id_fkey": {
+          "name": "habit_logs_habit_id_fkey",
+          "tableName": "habit_logs",
+          "columns": ["habit_id"],
+          "referencedTable": "habits",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": { "name": "user_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "habit_id": { "name": "habit_id", "type": "uuid", "primaryKey": false, "notNull": true },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": { "name": "content", "type": "text", "primaryKey": false, "notNull": true },
+        "word_count": {
+          "name": "word_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_language_snap": {
+          "name": "ui_language_snap",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_skill_snap": {
+          "name": "target_skill_snap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_feedback": {
+          "name": "ai_feedback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_agent_type": {
+          "name": "ai_agent_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood_score": {
+          "name": "mood_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_score": {
+          "name": "energy_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_journal": {
+          "name": "uq_journal",
+          "columns": [
+            { "expression": "user_id", "isExpression": false, "asc": true, "nulls": "last" },
+            { "expression": "habit_id", "isExpression": false, "asc": true, "nulls": "last" },
+            { "expression": "entry_date", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "btree"
+        },
+        "idx_journal_ai_gin": {
+          "name": "idx_journal_ai_gin",
+          "columns": [
+            { "expression": "ai_feedback", "isExpression": false, "asc": true, "nulls": "last" }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "ifNotExists": false,
+          "using": "gin"
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_user_id_fkey": {
+          "name": "journal_entries_user_id_fkey",
+          "tableName": "journal_entries",
+          "columns": ["user_id"],
+          "referencedTable": "users",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_habit_id_fkey": {
+          "name": "journal_entries_habit_id_fkey",
+          "tableName": "journal_entries",
+          "columns": ["habit_id"],
+          "referencedTable": "habits",
+          "referencedColumns": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": { "columns": {}, "schemas": {}, "tables": {} }
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1742044800000,
       "tag": "0004_habit_name_max_80",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1742131200000,
+      "tag": "0005_journal_entries",
+      "breakpoints": true
     }
   ]
 }

--- a/src/modules/journal/journal.controller.ts
+++ b/src/modules/journal/journal.controller.ts
@@ -42,14 +42,26 @@ export function createJournalController(service: JournalService) {
      * @returns HTTP response with entries array or error
      */
     async listEntries(
-      request: FastifyRequest<{ Querystring: { habit_id: string; limit?: string } }>,
+      request: FastifyRequest<{
+        Querystring: { habit_id?: string; limit?: string; date?: string };
+      }>,
       reply: FastifyReply
     ) {
       try {
         const { id: userId } = request.user;
-        const habitId = request.query.habit_id;
+        const { habit_id: habitId, date } = request.query;
+
+        if (!habitId && !date) {
+          return reply.code(400).send({ error: "habit_id or date is required" });
+        }
+
+        if (date && !habitId) {
+          const entries = await service.listEntriesByDate(userId, date);
+          return reply.code(200).send(entries);
+        }
+
         const limit = request.query.limit ? parseInt(request.query.limit, 10) : 30;
-        const entries = await service.listEntries(userId, habitId, limit);
+        const entries = await service.listEntries(userId, habitId!, limit);
         return reply.code(200).send(entries);
       } catch (error) {
         return handleControllerError(error, reply);

--- a/src/modules/journal/journal.repository.ts
+++ b/src/modules/journal/journal.repository.ts
@@ -75,6 +75,19 @@ export function createJournalRepository(db: DrizzleDb) {
     },
 
     /**
+     * Finds all journal entries for a user on a specific date.
+     * @param userId - The user ID
+     * @param entryDate - The entry date in ISO format (YYYY-MM-DD)
+     * @returns Array of journal entries for that date
+     */
+    async findAllByDate(userId: string, entryDate: string): Promise<JournalEntry[]> {
+      return db
+        .select()
+        .from(journalEntries)
+        .where(and(eq(journalEntries.userId, userId), eq(journalEntries.entryDate, entryDate)));
+    },
+
+    /**
      * Creates a new journal entry.
      * @param data - The journal entry data to create
      * @returns The created journal entry

--- a/src/modules/journal/journal.routes.ts
+++ b/src/modules/journal/journal.routes.ts
@@ -89,9 +89,9 @@ export async function journalRoutes(fastify: FastifyInstance) {
       security: [{ bearerAuth: [] }],
       querystring: {
         type: "object",
-        required: ["habit_id"],
         properties: {
           habit_id: { type: "string", format: "uuid" },
+          date: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" },
           limit: { type: "integer", minimum: 1, maximum: 100, default: 30 },
         },
       },

--- a/src/modules/journal/journal.service.ts
+++ b/src/modules/journal/journal.service.ts
@@ -82,6 +82,16 @@ export function createJournalService({
     },
 
     /**
+     * Lists all journal entries for a user on a specific date (across all habits).
+     * @param userId - The user ID
+     * @param date - The entry date (YYYY-MM-DD)
+     * @returns Array of journal entries for that date
+     */
+    async listEntriesByDate(userId: string, date: string): Promise<JournalEntry[]> {
+      return journalRepo.findAllByDate(userId, date);
+    },
+
+    /**
      * Gets a journal entry by date.
      * @param userId - The user ID
      * @param habitId - The habit ID


### PR DESCRIPTION
## Summary
- Add `GET /journal/entries?date=YYYY-MM-DD` — returns all entries for a user on a given date (no `habit_id` required)
- `habit_id` remains supported; controller routes to the appropriate service method based on which param is present
- Register missing `0005_journal_entries` migration in `meta/_journal.json` + add `0005_snapshot.json`

## Test plan
- [ ] All 169 existing tests pass (`npm test`)
- [ ] `GET /journal/entries?date=2026-03-15` returns array of entries for that date
- [ ] `GET /journal/entries?habit_id=<uuid>` still works as before
- [ ] `GET /journal/entries` (no params) returns 400
- [ ] `yarn db:migrate:local` applies `0005_journal_entries` successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Novas Funcionalidades**
  * Adicionado suporte para consultar entradas de diário por data específica, complementando a filtragem por hábito existente e oferecendo uma nova forma de visualizar registros diários.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->