### PR TITLE
chore: remove JSDoc from journal module and add completedToday to Swagger

### DIFF
--- a/src/modules/habits/habits.routes.ts
+++ b/src/modules/habits/habits.routes.ts
@@ -40,6 +40,7 @@ const habitSchema = {
     planStatus: { type: "string" },
     streak: { type: "integer" },
     currentDay: { type: "integer" },
+    completedToday: { type: "boolean" },
     createdAt: { type: "string" },
     updatedAt: { type: "string" },
   },

--- a/src/modules/journal/journal.controller.ts
+++ b/src/modules/journal/journal.controller.ts
@@ -8,19 +8,8 @@ import {
 } from "./journal.types.js";
 import { handleControllerError } from "../../shared/utils/http.js";
 
-/**
- * Factory function to create a JournalController instance.
- * @param service - The journal service instance
- * @returns Controller with HTTP handlers for journal endpoints
- */
 export function createJournalController(service: JournalService) {
   return {
-    /**
-     * HTTP handler for creating a journal entry.
-     * @param request - The Fastify request object
-     * @param reply - The Fastify reply object
-     * @returns HTTP response with created entry or error
-     */
     async createEntry(
       request: FastifyRequest<{ Body: CreateJournalEntryInput }>,
       reply: FastifyReply
@@ -35,12 +24,6 @@ export function createJournalController(service: JournalService) {
       }
     },
 
-    /**
-     * HTTP handler for listing journal entries.
-     * @param request - The Fastify request object
-     * @param reply - The Fastify reply object
-     * @returns HTTP response with entries array or error
-     */
     async listEntries(
       request: FastifyRequest<{
         Querystring: { habit_id?: string; limit?: string; date?: string };
@@ -68,12 +51,6 @@ export function createJournalController(service: JournalService) {
       }
     },
 
-    /**
-     * HTTP handler for getting a journal entry by date.
-     * @param request - The Fastify request object
-     * @param reply - The Fastify reply object
-     * @returns HTTP response with entry or error
-     */
     async getEntryByDate(
       request: FastifyRequest<{ Params: { date: string }; Querystring: { habit_id: string } }>,
       reply: FastifyReply
@@ -92,12 +69,6 @@ export function createJournalController(service: JournalService) {
       }
     },
 
-    /**
-     * HTTP handler for updating a journal entry.
-     * @param request - The Fastify request object
-     * @param reply - The Fastify reply object
-     * @returns HTTP response with updated entry or error
-     */
     async updateEntry(
       request: FastifyRequest<{ Params: { id: string }; Body: UpdateJournalEntryInput }>,
       reply: FastifyReply
@@ -114,7 +85,4 @@ export function createJournalController(service: JournalService) {
   };
 }
 
-/**
- * Type representing the JournalController instance.
- */
 export type JournalController = ReturnType<typeof createJournalController>;

--- a/src/modules/journal/journal.service.ts
+++ b/src/modules/journal/journal.service.ts
@@ -11,32 +11,16 @@ type JournalServiceDeps = {
   userProfilesRepo: UserProfilesRepository;
 };
 
-/**
- * Counts the number of words in a text string.
- * @param text - The text to count words in
- * @returns The number of words
- */
 function countWords(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;
 }
 
-/**
- * Factory function to create a JournalService instance.
- * @param deps - The service dependencies (repositories)
- * @returns Service with business logic methods for journal entries
- */
 export function createJournalService({
   journalRepo,
   habitsRepo,
   userProfilesRepo,
 }: JournalServiceDeps) {
   return {
-    /**
-     * Creates or updates a journal entry for today (idempotent).
-     * @param userId - The user ID
-     * @param input - The journal entry input data
-     * @returns The created or updated journal entry
-     */
     async createEntry(userId: string, input: CreateJournalEntryInput): Promise<JournalEntry> {
       const habit = await habitsRepo.findById(input.habitId, userId);
       if (!habit) throw new NotFoundError("Habit not found");
@@ -63,13 +47,6 @@ export function createJournalService({
       });
     },
 
-    /**
-     * Lists all journal entries for a habit.
-     * @param userId - The user ID
-     * @param habitId - The habit ID
-     * @param limit - Maximum number of entries to return
-     * @returns Array of journal entries
-     */
     async listEntries(
       userId: string,
       habitId: string,
@@ -81,23 +58,10 @@ export function createJournalService({
       return journalRepo.findAllByHabitId(habitId, userId, limit);
     },
 
-    /**
-     * Lists all journal entries for a user on a specific date (across all habits).
-     * @param userId - The user ID
-     * @param date - The entry date (YYYY-MM-DD)
-     * @returns Array of journal entries for that date
-     */
     async listEntriesByDate(userId: string, date: string): Promise<JournalEntry[]> {
       return journalRepo.findAllByDate(userId, date);
     },
 
-    /**
-     * Gets a journal entry by date.
-     * @param userId - The user ID
-     * @param habitId - The habit ID
-     * @param date - The entry date (YYYY-MM-DD)
-     * @returns The journal entry or null if not found
-     */
     async getEntryByDate(
       userId: string,
       habitId: string,
@@ -109,13 +73,6 @@ export function createJournalService({
       return journalRepo.findByHabitAndDate(habitId, userId, date);
     },
 
-    /**
-     * Updates a journal entry. Clears AI feedback if content changes.
-     * @param userId - The user ID
-     * @param entryId - The journal entry ID
-     * @param input - The fields to update
-     * @returns The updated journal entry
-     */
     async updateEntry(
       userId: string,
       entryId: string,
@@ -145,7 +102,4 @@ export function createJournalService({
   };
 }
 
-/**
- * Type representing the JournalService instance.
- */
 export type JournalService = ReturnType<typeof createJournalService>;


### PR DESCRIPTION
## Summary
- Remove all JSDoc comments from `journal.controller.ts` and `journal.service.ts` — the code is self-explanatory and comments were duplicating function signatures
- Add `completedToday: boolean` to `habitSchema` properties in Swagger docs (not required, as it's a computed field not yet in serializer)

## Test plan
- [ ] All unit, integration, and E2E tests pass (pre-commit hook verified)
- [ ] Swagger UI reflects `completedToday` in habit response shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Limpeza de documentação interna e remoção de comentários não essenciais no código.
  * Otimização de estruturas de código para melhor manutenibilidade.

* **Melhorias**
  * Aprimoramentos na camada de dados para suportar novos atributos opcionais em funcionalidades existentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->