### PR TITLE
refactor: add shared utils (date, json) and expand shared constants

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -20,7 +20,13 @@ function parseMs(expiresIn: string): number {
 }
 
 export const MAX_ACTIVE_HABITS = 5;
+export const AI_RATE_LIMIT_MS = 5_000;
 export const WARN_ACTIVE_HABITS = 3;
+export const MAX_HABIT_DAYS = 66;
+export const MAX_AI_REQUESTS_PER_DAY = 10;
+export const GEMINI_TIMEOUT_MS = 30_000;
+export const GEMINI_MAX_RETRIES = 3;
+export const GEMINI_RETRY_BASE_MS = 5_000;
 export const BCRYPT_ROUNDS = 12;
 export const ACCESS_TOKEN_EXPIRES = env.JWT_ACCESS_EXPIRES;
 export const REFRESH_TOKEN_EXPIRES = env.JWT_REFRESH_EXPIRES;

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -1,0 +1,14 @@
+export function getTodayUTCString(): string {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+    .toISOString()
+    .slice(0, 10);
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}

--- a/src/shared/utils/json.ts
+++ b/src/shared/utils/json.ts
@@ -1,0 +1,11 @@
+export function sanitizeJsonString(text: string): string {
+  let cleaned = text.replace(/^```json\n?|\n?```$/g, "").trim();
+  cleaned = cleaned.replace(/^```\n?|\n?```$/g, "").trim();
+  cleaned = cleaned.replace(/: '([\s\S]*?)'(?=[,}\]])/g, (_, content: string) => {
+    const escaped = content.replace(/"/g, '\\"');
+    return `: "${escaped}"`;
+  });
+  cleaned = cleaned.replace(/,(\s*[}\]])/g, "$1");
+  cleaned = cleaned.replace(/"\s+/g, '" ').replace(/\s+"/g, ' "');
+  return cleaned;
+}


### PR DESCRIPTION
## Summary
- Add `src/shared/utils/date.ts` with `getTodayUTCString()` and `isSameDay()` — extracted from duplicated inline implementations across modules
- Add `src/shared/utils/json.ts` with `sanitizeJsonString()` — to be extracted from `gemini-client.ts` in a follow-up PR
- Expand `src/shared/constants.ts` with `AI_RATE_LIMIT_MS`, `MAX_HABIT_DAYS`, `MAX_AI_REQUESTS_PER_DAY`, `GEMINI_TIMEOUT_MS`, `GEMINI_MAX_RETRIES`, `GEMINI_RETRY_BASE_MS` — centralizes all magic numbers (DRY)

## Test plan
- [ ] All unit, integration, and E2E tests pass
- [ ] No consumer modules changed yet (follow-up PRs wire these up)