### PR TITLE
chore: decouple Gemini URL via env, use shared constants, extract langInstruction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ JWT_REFRESH_EXPIRES=7d
 
 # AI Integration (Gemini — https://aistudio.google.com/apikey)
 GEMINI_API_KEY=your-gemini-api-key-from-aistudio
+# Override to use a different model or AI provider compatible with the Gemini API
+GEMINI_API_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent
 
 # Optional: Rate Limiting
 RATE_LIMIT_MAX=100

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -23,6 +23,11 @@ const envSchema = z.object({
   JWT_ACCESS_EXPIRES: z.string().default("15m"),
   JWT_REFRESH_EXPIRES: z.string().default("7d"),
   GEMINI_API_KEY: z.string().optional(),
+  GEMINI_API_URL: z
+    .url()
+    .default(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent"
+    ),
   SUPABASE_URL: z.url(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
   SUPABASE_STORAGE_BUCKET: z.string().default("avatars"),

--- a/src/modules/ai-agents/gemini-client.ts
+++ b/src/modules/ai-agents/gemini-client.ts
@@ -1,12 +1,11 @@
 import { env } from "../../core/config/env.js";
 import { logger } from "../../core/config/logger.js";
-
-const GEMINI_API_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
-
-const GEMINI_TIMEOUT_MS = 30_000;
-const GEMINI_MAX_RETRIES = 3;
-const GEMINI_RETRY_BASE_MS = 5_000;
+import {
+  GEMINI_TIMEOUT_MS,
+  GEMINI_MAX_RETRIES,
+  GEMINI_RETRY_BASE_MS,
+} from "../../shared/constants.js";
+export { sanitizeJsonString } from "../../shared/utils/json.js";
 
 export class GeminiRateLimitError extends Error {
   constructor(message: string) {
@@ -24,7 +23,7 @@ async function callGeminiOnce(
   const timeout = setTimeout(() => controller.abort(), GEMINI_TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${GEMINI_API_URL}`, {
+    const response = await fetch(env.GEMINI_API_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -83,17 +82,5 @@ export async function callGemini(prompt: string, maxOutputTokens: number): Promi
       throw error;
     }
   }
-  throw new Error("Unreachable: loop always exits via return or throw");
-}
-
-export function sanitizeJsonString(text: string): string {
-  let cleaned = text.replace(/^```json\n?|\n?```$/g, "").trim();
-  cleaned = cleaned.replace(/^```\n?|\n?```$/g, "").trim();
-  cleaned = cleaned.replace(/: '([\s\S]*?)'(?=[,}\]])/g, (_, content: string) => {
-    const escaped = content.replace(/"/g, '\\"');
-    return `: "${escaped}"`;
-  });
-  cleaned = cleaned.replace(/,(\s*[}\]])/g, "$1");
-  cleaned = cleaned.replace(/"\s+/g, '" ').replace(/\s+"/g, ' "');
-  return cleaned;
+  throw new Error("callGemini: exhausted retries without result");
 }

--- a/src/modules/ai-agents/utils.ts
+++ b/src/modules/ai-agents/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Generates a language instruction string for AI prompts based on a UI language code.
+ * Sanitizes the input to strip control characters and quotes, and falls back to "pt-BR".
+ * @param uiLanguage - The UI language code (e.g., "pt-BR", "en-US")
+ * @returns Instruction string for the AI
+ */
+export function langInstruction(uiLanguage: string): string {
+  const safeLanguage = uiLanguage.replace(/[\r\n"]/g, "").trim() || "pt-BR";
+  return `IMPORTANT: Write ALL text fields in the language with code "${safeLanguage}" (e.g. pt-BR = Brazilian Portuguese, en-US = English, es-ES = Spanish).`;
+}

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -1,11 +1,15 @@
 import { env } from "../../core/config/env.js";
 import { habitPlanSchema, type HabitPlan } from "./habit-plan.schema.js";
 import type { HabitMode } from "../../shared/schemas/habit-mode.js";
-import { TooManyRequestsError } from "../../shared/errors/index.js";
 import { logger } from "../../core/config/logger.js";
-
-const GEMINI_API_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
+import {
+  GEMINI_TIMEOUT_MS,
+  GEMINI_MAX_RETRIES,
+  GEMINI_RETRY_BASE_MS,
+} from "../../shared/constants.js";
+import { sanitizeJsonString } from "../../shared/utils/json.js";
+import { GeminiRateLimitError } from "../ai-agents/gemini-client.js";
+import { langInstruction } from "../ai-agents/utils.js";
 
 type PlannerInput = {
   name: string;
@@ -15,11 +19,6 @@ type PlannerInput = {
   level: string;
   uiLanguage?: string;
 };
-
-function langInstruction(uiLanguage: string): string {
-  const safeLanguage = uiLanguage.replace(/[\r\n"]/g, "").trim() || "pt-BR";
-  return `IMPORTANT: Write ALL text fields in the language with code "${safeLanguage}" (e.g. pt-BR = Brazilian Portuguese, en-US = English, es-ES = Spanish).`;
-}
 
 function buildFullTemplate(input: PlannerInput): string {
   return `You are a habit coach creating a 66-day skill-building plan.
@@ -72,17 +71,6 @@ Generate a lightweight 66-day consistency plan with EXACTLY 3 phases. Be extreme
 }
 
 IMPORTANT: Output must be complete, valid JSON only. No markdown.`;
-}
-
-const GEMINI_TIMEOUT_MS = 30_000;
-const GEMINI_MAX_RETRIES = 3;
-const GEMINI_RETRY_BASE_MS = 5_000;
-
-export class GeminiRateLimitError extends TooManyRequestsError {
-  constructor(message: string) {
-    super(message);
-    this.name = "GeminiRateLimitError";
-  }
 }
 
 const FULL_PLAN_RESPONSE_SCHEMA = {
@@ -161,7 +149,7 @@ async function callGeminiOnce(
 
   let response: Response;
   try {
-    response = await fetch(GEMINI_API_URL, {
+    response = await fetch(env.GEMINI_API_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -231,20 +219,7 @@ async function callGemini(
       throw error;
     }
   }
-  throw new Error("Unreachable: loop always exits via return or throw");
-}
-
-function sanitizeJsonString(text: string): string {
-  let cleaned = text.replace(/^```json\n?|\n?```$/g, "").trim();
-  cleaned = cleaned.replace(/^```\n?|\n?```$/g, "").trim();
-
-  cleaned = cleaned.replace(/: '([\s\S]*?)'(?=[,}\]])/g, ': "$1"');
-
-  cleaned = cleaned.replace(/,(\s*[}\]])/g, "$1");
-
-  cleaned = cleaned.replace(/"\s+/g, '" ').replace(/\s+"/g, ' "');
-
-  return cleaned;
+  throw new Error("callGemini: exhausted retries without result");
 }
 
 export async function generateHabitPlan(input: PlannerInput, mode: HabitMode): Promise<HabitPlan> {

--- a/tests/unit/habit-planner.test.ts
+++ b/tests/unit/habit-planner.test.ts
@@ -1,7 +1,11 @@
 import { generateHabitPlan } from "@/modules/habits/habit-planner.js";
 
 jest.mock("@/core/config/env.js", () => ({
-  env: { GEMINI_API_KEY: "test-gemini-key" },
+  env: {
+    GEMINI_API_KEY: "test-gemini-key",
+    GEMINI_API_URL: "https://gemini.test",
+    JWT_REFRESH_EXPIRES: "7d",
+  },
 }));
 
 const mockFetch = jest.fn();
@@ -96,7 +100,7 @@ describe("generateHabitPlan — skill-building (full)", () => {
     expect(plan.phases).toHaveLength(3);
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("gemini-flash-latest");
+    expect(url).toContain("https://gemini.test");
     expect(url).not.toContain("test-gemini-key");
     expect((init.headers as Record<string, string>)["x-goog-api-key"]).toBe("test-gemini-key");
     const body = JSON.parse(init.body as string) as {
@@ -164,7 +168,13 @@ describe("generateHabitPlan — failures", () => {
 
   it("throws when GEMINI_API_KEY is not configured", async () => {
     jest.resetModules();
-    jest.doMock("@/core/config/env.js", () => ({ env: { GEMINI_API_KEY: undefined } }));
+    jest.doMock("@/core/config/env.js", () => ({
+      env: {
+        GEMINI_API_KEY: undefined,
+        GEMINI_API_URL: "https://gemini.test",
+        JWT_REFRESH_EXPIRES: "7d",
+      },
+    }));
 
     const { generateHabitPlan: generateWithoutKey } =
       await import("@/modules/habits/habit-planner.js");


### PR DESCRIPTION
## Summary
- Add `GEMINI_API_URL` to env schema with default pointing to `gemini-flash-latest` — allows overriding the URL without code changes
- Document `GEMINI_API_URL` in `.env.example`
- `gemini-client.ts`: replace hardcoded URL with `env.GEMINI_API_URL`, import Gemini constants from `shared/constants`, re-export `sanitizeJsonString` from `shared/utils/json`
- `habit-planner.ts`: same constants import + `sanitizeJsonString` + `langInstruction` from new `utils.ts`; fix TypeScript error (missing return after exhausted retries loop)
- Add `src/modules/ai-agents/utils.ts` with `langInstruction()` helper (used by both planner and AI agents)
- Fix test: `habit-planner.test.ts` now provides `GEMINI_API_URL` and `JWT_REFRESH_EXPIRES` in env mock

## Test plan
- [ ] All unit, integration, and E2E tests pass
- [ ] `GEMINI_API_URL` env var overrides the Gemini endpoint at runtime