### PR TITLE
refactor: apply OCP to orchestrator — exhaustive Record<HabitMode, Agent>

### DIFF
--- a/src/modules/ai-agents/orchestrator.ts
+++ b/src/modules/ai-agents/orchestrator.ts
@@ -1,59 +1,34 @@
 import type { HabitMode } from "../../shared/schemas/habit-mode.js";
 
-/**
- * Represents an AI agent with its metadata.
- */
 export interface Agent {
   type: "language-teacher" | "behavioral-coach";
   name: string;
   description: string;
 }
 
-/**
- * Registry of available AI agents.
- */
-export const AGENTS: Record<string, Agent> = {
-  "language-teacher": {
+const AGENTS: Record<HabitMode, Agent> = {
+  "skill-building": {
     type: "language-teacher",
     name: "Language Teacher",
     description: "AI agent specialized in language learning and conversation practice",
   },
-  "behavioral-coach": {
+  "tracking-coached": {
     type: "behavioral-coach",
     name: "Behavioral Coach",
     description: "AI agent specialized in behavior change and habit coaching",
   },
 };
 
-/**
- * Dependencies required by the orchestrator.
- */
 export type OrchestratorDeps = {
   deriveHabitMode: (targetSkill: string) => HabitMode;
 };
 
-/**
- * Factory function to create an orchestrator instance.
- * @param deps - The dependencies including deriveHabitMode function
- * @returns Orchestrator with route method
- */
 export function createOrchestrator({ deriveHabitMode }: OrchestratorDeps) {
   return {
-    /**
-     * Routes to the appropriate agent based on habit mode.
-     * @param targetSkill - The target skill from the habit (e.g., "en-US", "fitness")
-     * @returns The appropriate agent for the given habit mode
-     */
     route(targetSkill: string): Agent {
-      const habitMode = deriveHabitMode(targetSkill);
-      return habitMode === "skill-building"
-        ? AGENTS["language-teacher"]
-        : AGENTS["behavioral-coach"];
+      return AGENTS[deriveHabitMode(targetSkill)];
     },
   };
 }
 
-/**
- * Type representing the orchestrator instance.
- */
 export type Orchestrator = ReturnType<typeof createOrchestrator>;

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { createOrchestrator, AGENTS } from "@/modules/ai-agents/orchestrator.js";
+import { createOrchestrator } from "@/modules/ai-agents/orchestrator.js";
 
 describe("Orchestrator", () => {
   describe("route", () => {
@@ -10,10 +10,10 @@ describe("Orchestrator", () => {
 
       const orchestrator = createOrchestrator({ deriveHabitMode: mockDeriveHabitMode });
 
-      expect(orchestrator.route("en-US")).toEqual(AGENTS["language-teacher"]);
-      expect(orchestrator.route("es-ES")).toEqual(AGENTS["language-teacher"]);
-      expect(orchestrator.route("fr-FR")).toEqual(AGENTS["language-teacher"]);
-      expect(orchestrator.route("pt-BR")).toEqual(AGENTS["language-teacher"]);
+      expect(orchestrator.route("en-US").type).toBe("language-teacher");
+      expect(orchestrator.route("es-ES").type).toBe("language-teacher");
+      expect(orchestrator.route("fr-FR").type).toBe("language-teacher");
+      expect(orchestrator.route("pt-BR").type).toBe("language-teacher");
       expect(mockDeriveHabitMode).toHaveBeenCalledTimes(4);
     });
 
@@ -25,10 +25,10 @@ describe("Orchestrator", () => {
 
       const orchestrator = createOrchestrator({ deriveHabitMode: mockDeriveHabitMode });
 
-      expect(orchestrator.route("fitness")).toEqual(AGENTS["behavioral-coach"]);
-      expect(orchestrator.route("mindfulness")).toEqual(AGENTS["behavioral-coach"]);
-      expect(orchestrator.route("general")).toEqual(AGENTS["behavioral-coach"]);
-      expect(orchestrator.route("cooking")).toEqual(AGENTS["behavioral-coach"]);
+      expect(orchestrator.route("fitness").type).toBe("behavioral-coach");
+      expect(orchestrator.route("mindfulness").type).toBe("behavioral-coach");
+      expect(orchestrator.route("general").type).toBe("behavioral-coach");
+      expect(orchestrator.route("cooking").type).toBe("behavioral-coach");
       expect(mockDeriveHabitMode).toHaveBeenCalledTimes(4);
     });
 
@@ -43,18 +43,6 @@ describe("Orchestrator", () => {
       expect(agent).toHaveProperty("name");
       expect(agent).toHaveProperty("description");
       expect(agent.type).toBe("language-teacher");
-    });
-  });
-
-  describe("AGENTS constant", () => {
-    it("contains both available agents", () => {
-      expect(AGENTS).toHaveProperty("language-teacher");
-      expect(AGENTS).toHaveProperty("behavioral-coach");
-    });
-
-    it("has correct agent types", () => {
-      expect(AGENTS["language-teacher"].type).toBe("language-teacher");
-      expect(AGENTS["behavioral-coach"].type).toBe("behavioral-coach");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace `Record<string, Agent>` (keyed by agent type) with `Record<HabitMode, Agent>` (keyed by habit mode)
- `route()` now does a direct map lookup — no if/else, no string comparison
- Adding a new `HabitMode` forces TypeScript to require a matching `Agent` entry (Open/Closed Principle)
- `AGENTS` is now module-private — tests updated to assert `.type` instead of deep-equal with exported constant

## Why
The previous `if/else` in `route()` would need to change every time a new agent type is added. With an exhaustive `Record<HabitMode, Agent>`, `route()` never needs to change — only the map grows.

## Test plan
- [ ] All unit, integration, and E2E tests pass
- [ ] TypeScript enforces exhaustiveness at compile time (missing HabitMode = TS error)