### PR TITLE
refactor: centralize AI rate limit logic and fix HTTP 403→429

### DIFF
--- a/src/modules/ai-agents/ai.routes.ts
+++ b/src/modules/ai-agents/ai.routes.ts
@@ -51,7 +51,7 @@ export async function aiRoutes(fastify: FastifyInstance) {
           },
         },
         401: errorResponse("Unauthorized"),
-        403: errorResponse("Rate limit exceeded"),
+        429: errorResponse("Rate limit exceeded"),
         404: errorResponse("Journal entry or habit not found"),
       },
     },

--- a/src/modules/ai-agents/ai.service.ts
+++ b/src/modules/ai-agents/ai.service.ts
@@ -6,14 +6,13 @@ import { deriveHabitMode, type TargetSkill } from "../../shared/schemas/habit-mo
 import { createOrchestrator } from "./orchestrator.js";
 import { analyzeWithLanguageAgent } from "./language-agent.js";
 import { analyzeWithBehavioralAgent } from "./behavioral-agent.js";
-import { NotFoundError, ForbiddenError } from "../../shared/errors/index.js";
+import { NotFoundError } from "../../shared/errors/index.js";
 import type { LanguageAgentResponse } from "./language-agent.js";
 import type { BehavioralAgentResponse } from "./behavioral-agent.js";
 import type { JournalRepository } from "../journal/journal.repository.js";
 import type { HabitsRepository } from "../habits/habits.repository.js";
 import type { UserProfilesRepository } from "../users/user-profiles.repository.js";
-
-const MAX_AI_REQUESTS_PER_DAY = 10;
+import { assertAiRateLimit, nextAiRequestCount } from "../../shared/utils/ai-rate-limit.js";
 
 export type AiAnalyzeInput = {
   journalEntryId: string;
@@ -65,23 +64,15 @@ export function createAiService(deps: AiServiceDeps) {
     aiRequestsToday: number;
     lastAiRequest: Date | null;
   }) {
-    const now = new Date();
-    const lastRequest = profile.lastAiRequest;
+    const rateLimitProfile = {
+      aiRequestsToday: profile.aiRequestsToday,
+      lastAiRequest: profile.lastAiRequest,
+    };
 
-    const isSameDay =
-      lastRequest &&
-      lastRequest.getFullYear() === now.getFullYear() &&
-      lastRequest.getMonth() === now.getMonth() &&
-      lastRequest.getDate() === now.getDate();
-
-    const currentCount = isSameDay ? profile.aiRequestsToday : 0;
-
-    if (currentCount >= MAX_AI_REQUESTS_PER_DAY) {
-      throw new ForbiddenError(`AI request limit of ${MAX_AI_REQUESTS_PER_DAY} per day exceeded`);
-    }
+    assertAiRateLimit(rateLimitProfile);
 
     await userProfilesRepo.upsert(profile.userId, {
-      aiRequestsToday: currentCount + 1,
+      aiRequestsToday: nextAiRequestCount(rateLimitProfile),
       lastAiRequest: new Date(),
     });
   }

--- a/src/modules/habits/habits.service.ts
+++ b/src/modules/habits/habits.service.ts
@@ -3,14 +3,32 @@ import type { HabitLogsRepository } from "./habit-logs.repository.js";
 import type { UserProfilesRepository } from "../users/user-profiles.repository.js";
 import type { Habit, HabitLog } from "../../core/database/schema/index.js";
 import { logger } from "../../core/config/logger.js";
+import {
+  NotFoundError,
+  TooManyRequestsError,
+  UnprocessableError,
+} from "../../shared/errors/index.js";
+import { deriveHabitMode } from "../../shared/schemas/habit-mode.js";
+import type {
+  CheckInInput,
+  CreateHabitInput,
+  CreateWithPlanInput,
+  PreviewPlanInput,
+  RegeneratePlanInput,
+  UpdateHabitInput,
+} from "./habits.types.js";
+import { generateHabitPlan } from "./habit-planner.js";
+import type { HabitPlan } from "./habit-plan.schema.js";
+import { MAX_HABIT_DAYS, MAX_ACTIVE_HABITS } from "../../shared/constants.js";
+import { getTodayUTCString } from "../../shared/utils/date.js";
+import { assertAiRateLimit, nextAiRequestCount } from "../../shared/utils/ai-rate-limit.js";
 
-export type HabitWithStats = Habit & { streak: number; currentDay: number };
+export type HabitWithStats = Habit & {
+  streak: number;
+  currentDay: number;
+  completedToday: boolean;
+};
 
-/**
- * Computes the current day number based on the habit start date.
- * @param startDate - The habit start date
- * @returns Current day number (1-66)
- */
 function computeCurrentDay(startDate: string | Date | null): number {
   if (!startDate) return 1;
   const start = new Date(startDate);
@@ -19,14 +37,9 @@ function computeCurrentDay(startDate: string | Date | null): number {
   const startUTC = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
   const nowUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
   const diff = Math.floor((nowUTC - startUTC) / (1000 * 60 * 60 * 24));
-  return Math.max(1, Math.min(diff + 1, 66));
+  return Math.max(1, Math.min(diff + 1, MAX_HABIT_DAYS));
 }
 
-/**
- * Computes the current streak of completed days for a habit.
- * @param logs - Array of habit logs
- * @returns Number of consecutive completed days
- */
 function computeStreak(logs: HabitLog[]): number {
   const completedDates = new Set(logs.filter((l) => l.completed).map((l) => l.logDate));
   if (completedDates.size === 0) return 0;
@@ -56,39 +69,15 @@ function computeStreak(logs: HabitLog[]): number {
   return streak;
 }
 
-/**
- * Enriches a habit with computed statistics.
- * @param habit - The habit entity
- * @param logs - Array of habit logs
- * @returns Habit with streak and current day
- */
 function enrichHabit(habit: Habit, logs: HabitLog[]): HabitWithStats {
+  const todayStr = getTodayUTCString();
   return {
     ...habit,
     streak: computeStreak(logs),
     currentDay: computeCurrentDay(habit.startDate),
+    completedToday: logs.some((l) => l.logDate === todayStr && l.completed),
   };
 }
-import {
-  NotFoundError,
-  TooManyRequestsError,
-  UnprocessableError,
-} from "../../shared/errors/index.js";
-import { deriveHabitMode } from "../../shared/schemas/habit-mode.js";
-import type {
-  CheckInInput,
-  CreateHabitInput,
-  CreateWithPlanInput,
-  PreviewPlanInput,
-  RegeneratePlanInput,
-  UpdateHabitInput,
-} from "./habits.types.js";
-import { generateHabitPlan } from "./habit-planner.js";
-import type { HabitPlan } from "./habit-plan.schema.js";
-
-export const MAX_ACTIVE_HABITS = 5;
-const MAX_AI_REQUESTS_PER_DAY = 10;
-const AI_RATE_LIMIT_MS = 5000;
 
 type HabitsServiceDeps = {
   habitsRepo: HabitsRepository;
@@ -96,51 +85,22 @@ type HabitsServiceDeps = {
   userProfilesRepo: UserProfilesRepository;
 };
 
-/**
- * Factory function to create a HabitsService instance.
- * @param deps - The service dependencies (repositories)
- * @returns Service with business logic methods for habits
- */
 export function createHabitsService({
   habitsRepo,
   habitLogsRepo,
   userProfilesRepo,
 }: HabitsServiceDeps) {
-  /**
-   * Checks and increments AI usage for a user.
-   * Enforces rate limit (5s) and daily limit (10 requests).
-   * Resets daily counter when a new day begins.
-   * @param userId - The user ID
-   * @throws TooManyRequestsError if limits are exceeded
-   */
   async function checkAndIncrementAiUsage(userId: string): Promise<void> {
     const profile = await userProfilesRepo.findByUserId(userId);
+    const rateLimitProfile = {
+      aiRequestsToday: profile?.aiRequestsToday ?? 0,
+      lastAiRequest: profile?.lastAiRequest ?? null,
+    };
 
-    if (profile?.lastAiRequest) {
-      const elapsed = Date.now() - profile.lastAiRequest.getTime();
-      if (elapsed < AI_RATE_LIMIT_MS) {
-        throw new TooManyRequestsError("AI rate limit: wait 5 seconds between requests");
-      }
-    }
-
-    const now = new Date();
-    const lastRequest = profile?.lastAiRequest ?? null;
-    const isSameDay =
-      lastRequest &&
-      lastRequest.getFullYear() === now.getFullYear() &&
-      lastRequest.getMonth() === now.getMonth() &&
-      lastRequest.getDate() === now.getDate();
-
-    const currentCount = isSameDay ? (profile?.aiRequestsToday ?? 0) : 0;
-
-    if (currentCount >= MAX_AI_REQUESTS_PER_DAY) {
-      throw new TooManyRequestsError(
-        `AI request limit of ${MAX_AI_REQUESTS_PER_DAY} per day exceeded`
-      );
-    }
+    assertAiRateLimit(rateLimitProfile);
 
     await userProfilesRepo.upsert(userId, {
-      aiRequestsToday: currentCount + 1,
+      aiRequestsToday: nextAiRequestCount(rateLimitProfile),
       lastAiRequest: new Date(),
     });
   }

--- a/src/shared/utils/ai-rate-limit.ts
+++ b/src/shared/utils/ai-rate-limit.ts
@@ -1,0 +1,31 @@
+import { isSameDay } from "./date.js";
+import { TooManyRequestsError } from "../errors/index.js";
+import { MAX_AI_REQUESTS_PER_DAY, AI_RATE_LIMIT_MS } from "../constants.js";
+
+type RateLimitProfile = {
+  aiRequestsToday: number;
+  lastAiRequest: Date | null;
+};
+
+export function assertAiRateLimit({ aiRequestsToday, lastAiRequest }: RateLimitProfile): void {
+  if (lastAiRequest) {
+    const elapsed = Date.now() - lastAiRequest.getTime();
+    if (elapsed < AI_RATE_LIMIT_MS) {
+      throw new TooManyRequestsError("AI rate limit: wait 5 seconds between requests");
+    }
+  }
+
+  const sameDay = lastAiRequest && isSameDay(lastAiRequest, new Date());
+  const currentCount = sameDay ? aiRequestsToday : 0;
+
+  if (currentCount >= MAX_AI_REQUESTS_PER_DAY) {
+    throw new TooManyRequestsError(
+      `AI request limit of ${MAX_AI_REQUESTS_PER_DAY} per day exceeded`
+    );
+  }
+}
+
+export function nextAiRequestCount({ aiRequestsToday, lastAiRequest }: RateLimitProfile): number {
+  const sameDay = lastAiRequest && isSameDay(lastAiRequest, new Date());
+  return sameDay ? aiRequestsToday + 1 : 1;
+}

--- a/tests/unit/ai.service.test.ts
+++ b/tests/unit/ai.service.test.ts
@@ -1,5 +1,5 @@
 import { createAiService, type AiServiceDeps } from "@/modules/ai-agents/ai.service.js";
-import { NotFoundError, ForbiddenError } from "@/shared/errors/index.js";
+import { NotFoundError, TooManyRequestsError } from "@/shared/errors/index.js";
 import type { JournalRepository } from "@/modules/journal/journal.repository.js";
 import type { HabitsRepository } from "@/modules/habits/habits.repository.js";
 import type { UserProfilesRepository } from "@/modules/users/user-profiles.repository.js";
@@ -67,7 +67,7 @@ const mockProfile: UserProfile = {
   bio: null,
   timezone: "America/Sao_Paulo",
   aiRequestsToday: 2,
-  lastAiRequest: new Date(),
+  lastAiRequest: new Date(Date.now() - 10_000),
 };
 
 function makeService() {
@@ -134,7 +134,7 @@ describe("ai service", () => {
       ).rejects.toThrow(NotFoundError);
     });
 
-    it("throws ForbiddenError when rate limit exceeded", async () => {
+    it("throws TooManyRequestsError when rate limit exceeded", async () => {
       const { service, journalRepo, habitsRepo, userProfilesRepo } = makeService();
       journalRepo.findById.mockResolvedValue(mockJournalEntry);
       habitsRepo.findById.mockResolvedValue(mockHabit);
@@ -145,7 +145,7 @@ describe("ai service", () => {
           { journalEntryId: "journal-entry-id-1", habitId: "habit-id-1" },
           "user-id-1"
         )
-      ).rejects.toThrow(ForbiddenError);
+      ).rejects.toThrow(TooManyRequestsError);
     });
 
     it("calls language agent for skill-building habits", async () => {

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -1,4 +1,5 @@
-import { createHabitsService, MAX_ACTIVE_HABITS } from "@/modules/habits/habits.service.js";
+import { createHabitsService } from "@/modules/habits/habits.service.js";
+import { MAX_ACTIVE_HABITS } from "@/shared/constants.js";
 import { NotFoundError, TooManyRequestsError, UnprocessableError } from "@/shared/errors/index.js";
 import type { HabitsRepository } from "@/modules/habits/habits.repository.js";
 import type { HabitLogsRepository } from "@/modules/habits/habit-logs.repository.js";


### PR DESCRIPTION
## Summary
- Add `src/shared/utils/ai-rate-limit.ts` with `assertAiRateLimit()` and `nextAiRequestCount()` — single source of truth for AI rate limiting (DRY)
- `assertAiRateLimit` enforces two rules: 5-second cooldown between requests + 10 requests/day cap
- `habits.service.ts`: replace inline rate-limit code with `assertAiRateLimit`/`nextAiRequestCount` from shared utils; import `MAX_ACTIVE_HABITS` from `shared/constants` (was local)
- `ai.service.ts`: same DRY refactor; remove `ForbiddenError` import (now throws `TooManyRequestsError`)
- `ai.routes.ts`: fix HTTP status from `403` → `429` (rate limit is correctly 429 Too Many Requests)
- Tests updated: `habits.service.test.ts` imports `MAX_ACTIVE_HABITS` from shared; `ai.service.test.ts` uses `TooManyRequestsError` + adjusts `lastAiRequest` for 5s cooldown

## Why
Both `habits.service` and `ai.service` had duplicate rate-limit implementations that could drift. A single `assertAiRateLimit` ensures consistent enforcement. HTTP 403 was semantically wrong for rate limiting.

## Test plan
- [ ] All unit, integration, and E2E tests pass
- [ ] Rate limit throws 429 on the `/ai/analyze` endpoint
- [ ] Cooldown and daily cap enforced identically across both services