### PR TITLE
feat: add consents endpoint for LGPD compliance

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { healthRoutes } from "./modules/health/health.routes.js";
 import { usersRoutes } from "./modules/users/users.routes.js";
 import { aiRoutes } from "./modules/ai-agents/ai.routes.js";
 import { analyticsRoutes } from "./modules/analytics/analytics.routes.js";
+import { consentsRoutes } from "./modules/consents/consents.routes.js";
 import {
   cookiePlugin,
   corsPlugin,
@@ -34,6 +35,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(journalRoutes, { prefix: "/api" });
   await fastify.register(aiRoutes, { prefix: "/api" });
   await fastify.register(analyticsRoutes, { prefix: "/api" });
+  await fastify.register(consentsRoutes, { prefix: "/api" });
 
   return fastify;
 }

--- a/src/core/database/schema/consents.schema.ts
+++ b/src/core/database/schema/consents.schema.ts
@@ -1,0 +1,25 @@
+import { pgTable, uuid, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { users } from "./users.schema.js";
+
+export type ConsentType = "cookie_consent" | "privacy_policy" | "terms_of_use";
+
+export const consents = pgTable(
+  "consents",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: text("type").notNull(),
+    version: text("version").notNull(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }).notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+  },
+  (table) => ({
+    userTypeUnique: unique("consents_user_type_unique").on(table.userId, table.type),
+  })
+);
+
+export type Consent = typeof consents.$inferSelect;
+export type NewConsent = typeof consents.$inferInsert;

--- a/src/core/database/schema/index.ts
+++ b/src/core/database/schema/index.ts
@@ -4,3 +4,4 @@ export * from "./refresh-tokens.schema.js";
 export * from "./habits.schema.js";
 export * from "./habit-logs.schema.js";
 export * from "./journal-entries.schema.js";
+export * from "./consents.schema.js";

--- a/src/modules/consents/consents.controller.ts
+++ b/src/modules/consents/consents.controller.ts
@@ -1,0 +1,49 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { ConsentsService } from "./consents.service.js";
+
+export interface ConsentsController {
+  save(request: FastifyRequest, reply: FastifyReply): Promise<void>;
+  list(request: FastifyRequest, reply: FastifyReply): Promise<void>;
+}
+
+export function createConsentsController(service: ConsentsService): ConsentsController {
+  return {
+    async save(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+      try {
+        const { id: userId } = request.user;
+        const { type } = request.body as { type: string };
+
+        if (!type) {
+          reply.code(400).send({ error: "Consent type is required" });
+          return;
+        }
+
+        const validTypes = ["cookie_consent", "privacy_policy", "terms_of_use"];
+        if (!validTypes.includes(type)) {
+          reply.code(400).send({ error: "Invalid consent type" });
+          return;
+        }
+
+        const consent = await service.saveConsent(
+          userId,
+          type as "cookie_consent" | "privacy_policy" | "terms_of_use"
+        );
+        reply.code(201).send(consent);
+      } catch (error) {
+        request.log.error(error);
+        reply.code(500).send({ error: "Internal server error" });
+      }
+    },
+
+    async list(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+      try {
+        const { id: userId } = request.user;
+        const consents = await service.getConsents(userId);
+        reply.code(200).send(consents);
+      } catch (error) {
+        request.log.error(error);
+        reply.code(500).send({ error: "Internal server error" });
+      }
+    },
+  };
+}

--- a/src/modules/consents/consents.module.ts
+++ b/src/modules/consents/consents.module.ts
@@ -1,0 +1,12 @@
+import type { DrizzleDb } from "@/core/database/connection.js";
+import { createConsentsRepository } from "./consents.repository.js";
+import { createConsentsService } from "./consents.service.js";
+import { createConsentsController } from "./consents.controller.js";
+
+export function createConsentsModule(db: DrizzleDb) {
+  const repository = createConsentsRepository(db);
+  const service = createConsentsService(repository);
+  const controller = createConsentsController(service);
+
+  return { controller, service, repository };
+}

--- a/src/modules/consents/consents.repository.ts
+++ b/src/modules/consents/consents.repository.ts
@@ -1,0 +1,52 @@
+import { eq, and } from "drizzle-orm";
+import type { DrizzleDb } from "@/core/database/connection.js";
+import {
+  consents,
+  type Consent,
+  type ConsentType,
+} from "@/core/database/schema/consents.schema.js";
+
+export interface ConsentsRepository {
+  save(userId: string, type: ConsentType, version: string): Promise<Consent>;
+  findByUserId(userId: string): Promise<Consent[]>;
+  findByUserIdAndType(userId: string, type: ConsentType): Promise<Consent | null>;
+}
+
+export function createConsentsRepository(db: DrizzleDb): ConsentsRepository {
+  return {
+    async save(userId: string, type: ConsentType, version: string): Promise<Consent> {
+      const now = new Date();
+      const existing = await db.query.consents.findFirst({
+        where: and(eq(consents.userId, userId), eq(consents.type, type)),
+      });
+
+      if (existing) {
+        const updated = await db
+          .update(consents)
+          .set({ version, acceptedAt: now })
+          .where(and(eq(consents.userId, userId), eq(consents.type, type)))
+          .returning();
+        return updated[0];
+      }
+
+      const inserted = await db
+        .insert(consents)
+        .values({ userId, type, version, acceptedAt: now })
+        .returning();
+      return inserted[0];
+    },
+
+    async findByUserId(userId: string): Promise<Consent[]> {
+      return db.query.consents.findMany({
+        where: eq(consents.userId, userId),
+      });
+    },
+
+    async findByUserIdAndType(userId: string, type: ConsentType): Promise<Consent | null> {
+      const result = await db.query.consents.findFirst({
+        where: and(eq(consents.userId, userId), eq(consents.type, type)),
+      });
+      return result ?? null;
+    },
+  };
+}

--- a/src/modules/consents/consents.routes.ts
+++ b/src/modules/consents/consents.routes.ts
@@ -1,0 +1,85 @@
+import type { FastifyInstance } from "fastify";
+import { getDb } from "../../core/database/connection.js";
+import { authenticate } from "../../core/hooks/authenticate.js";
+import { createConsentsModule } from "./consents.module.js";
+
+const consentResponseSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    type: { type: "string", enum: ["cookie_consent", "privacy_policy", "terms_of_use"] },
+    version: { type: "string" },
+    acceptedAt: { type: "string" },
+  },
+};
+
+export async function consentsRoutes(fastify: FastifyInstance) {
+  const { controller } = createConsentsModule(getDb());
+
+  fastify.post("/consents", {
+    schema: {
+      description: "Save user consent for privacy policy, cookies, or terms of use",
+      tags: ["Consents"],
+      summary: "Save consent",
+      security: [{ bearerAuth: [] }],
+      body: {
+        type: "object",
+        required: ["type"],
+        properties: {
+          type: {
+            type: "string",
+            enum: ["cookie_consent", "privacy_policy", "terms_of_use"],
+            description: "Type of consent",
+          },
+        },
+      },
+      response: {
+        201: consentResponseSchema,
+        400: {
+          description: "Validation error",
+          type: "object",
+          properties: { error: { type: "string" } },
+        },
+        401: {
+          description: "Unauthorized",
+          type: "object",
+          properties: { error: { type: "string" } },
+        },
+        500: {
+          description: "Internal server error",
+          type: "object",
+          properties: { error: { type: "string" } },
+        },
+      },
+    },
+    preHandler: authenticate,
+    handler: controller.save,
+  });
+
+  fastify.get("/consents", {
+    schema: {
+      description: "Get all consents for the authenticated user",
+      tags: ["Consents"],
+      summary: "List consents",
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: {
+          type: "array",
+          items: consentResponseSchema,
+        },
+        401: {
+          description: "Unauthorized",
+          type: "object",
+          properties: { error: { type: "string" } },
+        },
+        500: {
+          description: "Internal server error",
+          type: "object",
+          properties: { error: { type: "string" } },
+        },
+      },
+    },
+    preHandler: authenticate,
+    handler: controller.list,
+  });
+}

--- a/src/modules/consents/consents.service.ts
+++ b/src/modules/consents/consents.service.ts
@@ -1,0 +1,40 @@
+import type { ConsentsRepository } from "./consents.repository.js";
+import type { ConsentType } from "@/core/database/schema/consents.schema.js";
+
+export interface ConsentResponse {
+  id: string;
+  type: ConsentType;
+  version: string;
+  acceptedAt: Date;
+}
+
+export interface ConsentsService {
+  saveConsent(userId: string, type: ConsentType): Promise<ConsentResponse>;
+  getConsents(userId: string): Promise<ConsentResponse[]>;
+}
+
+export function createConsentsService(repository: ConsentsRepository): ConsentsService {
+  const CONSENT_VERSION = "1.0";
+
+  return {
+    async saveConsent(userId: string, type: ConsentType): Promise<ConsentResponse> {
+      const consent = await repository.save(userId, type, CONSENT_VERSION);
+      return {
+        id: consent.id,
+        type: consent.type as ConsentType,
+        version: consent.version,
+        acceptedAt: consent.acceptedAt,
+      };
+    },
+
+    async getConsents(userId: string): Promise<ConsentResponse[]> {
+      const consents = await repository.findByUserId(userId);
+      return consents.map((c) => ({
+        id: c.id,
+        type: c.type as ConsentType,
+        version: c.version,
+        acceptedAt: c.acceptedAt,
+      }));
+    },
+  };
+}


### PR DESCRIPTION
Adiciona endpoint de consentimentos para conformidade LGPD.\n\nEndpoints:\n- POST /api/consents - Salvar consentimento\n- GET /api/consents - Listar consentimentos do usuário\n\nTipos de consentimento:\n- cookie_consent\n- privacy_policy\n- terms_of_use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Adicionado gerenciamento de consentimentos: os usuários agora podem salvar e acompanhar seus consentimentos de cookies, política de privacidade e termos de uso.
  * Adicionada funcionalidade de exclusão de conta: os usuários autenticados podem agora deletar suas contas fornecendo sua senha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->