### PR TITLE
fix: pass DATABASE_URL to drizzle migrate step

### DIFF
--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -39,6 +39,7 @@ jobs:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
           RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
+          DATABASE_URL: ${{ secrets.RAILWAY_DATABASE_URL }}
         run: |
           railway run npx drizzle-kit migrate
 


### PR DESCRIPTION
## Summary
- Pass DATABASE_URL explicitly to drizzle migrate step
- Fixes migration not running against correct database