### PR TITLE
fix: use drizzle-kit push --force for migrations

### DIFF
--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -41,7 +41,7 @@ jobs:
           RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
           DATABASE_URL: ${{ secrets.RAILWAY_DATABASE_URL }}
         run: |
-          railway run npx drizzle-kit migrate
+          railway run npx drizzle-kit push --force
 
       - name: Post-migration health check
         run: |


### PR DESCRIPTION
## Summary
- Use `drizzle-kit push --force` instead of `migrate`
- Forces schema sync to ensure all tables are created including consents
- Bypasses migration journal for fresh table creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Otimizado o processo de atualização do banco de dados durante o deployment para melhor eficiência na execução das alterações de schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->