### PR TITLE
fix: simplify CD — drizzle migrate com DATABASE_URL direto

### DIFF
--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   workflow_dispatch:
 
 concurrency:
@@ -12,8 +11,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: "Deploy to Railway"
+  migrate:
+    name: "Run migrations"
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -23,37 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Railway CLI
-        run: npm install -g @railway/cli
-
       - name: Install dependencies
         run: npm ci
 
-      - name: Deploy to Railway
-        env:
-          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
-          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
-        run: |
-          railway up --service imm-production
-
       - name: Run migrations
         env:
-          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
-          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
           DATABASE_URL: ${{ secrets.RAILWAY_DATABASE_URL }}
-        run: |
-          railway run npx drizzle-kit push --force
+        run: npx drizzle-kit migrate
 
-      - name: Post-migration health check
+      - name: Health check
         run: |
-          echo "Waiting for deployment to be ready..."
-          sleep 10
-          HEALTH_RESPONSE=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 30 https://api.insidemymind.tech/health || echo "000")
-          if [ "$HEALTH_RESPONSE" = "200" ]; then
-            echo "Health check passed (HTTP $HEALTH_RESPONSE)"
+          sleep 15
+          HEALTH=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 30 https://api.insidemymind.tech/health || echo "000")
+          if [ "$HEALTH" = "200" ]; then
+            echo "Health check passed (HTTP $HEALTH)"
           else
-            echo "Health check failed (HTTP $HEALTH_RESPONSE)"
+            echo "Health check failed (HTTP $HEALTH)"
             exit 1
           fi


### PR DESCRIPTION
## Problema

O `cd-railway.yml` nunca funcionou:
- `railway up` → `No linked project found` (secrets não configurados)
- `railway run npx drizzle-kit push --force` → falha por resolução de imports `.js` nos schemas TypeScript

## Solução

Railway já faz o deploy automático via integração nativa com GitHub. O workflow só precisa rodar as migrations.

- Remove `railway up` e `Install Railway CLI` (redundantes)
- Substitui `drizzle-kit push --force` por `drizzle-kit migrate` com `DATABASE_URL` passado direto
- Trigger apenas em push na `main` (único ambiente ativo)
- Secret `RAILWAY_DATABASE_URL` adicionado no repositório

## O que muda

| Antes | Depois |
|-------|--------|
| `railway up` (quebrado) | Railway nativo faz o deploy |
| `railway run npx drizzle-kit push --force` (quebrado) | `DATABASE_URL=... npx drizzle-kit migrate` (funciona) |
| Trigger em `main` e `develop` | Trigger só em `main` |

## Test plan

- [ ] Fazer push na main e confirmar que o workflow passa
- [ ] Confirmar que migrations futuras são aplicadas automaticamente