### PR TITLE
fix(ai): improve habit planner failures and fallback

### DIFF
--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -43,6 +43,14 @@ if (!parsedEnv.success) {
   process.exit(1);
 }
 
+if (
+  !["development", "test"].includes(parsedEnv.data.NODE_ENV) &&
+  new URL(parsedEnv.data.GEMINI_API_URL).protocol !== "https:"
+) {
+  logger.error("❌ GEMINI_API_URL must use HTTPS");
+  process.exit(1);
+}
+
 const geminiFallbackUrls = (process.env.GEMINI_API_FALLBACK_URLS ?? "")
   .split(",")
   .map((value) => value.trim())

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -48,10 +48,10 @@ const geminiFallbackUrls = (process.env.GEMINI_API_FALLBACK_URLS ?? "")
   .map((value) => value.trim())
   .filter(Boolean);
 
-for (const url of geminiFallbackUrls) {
+for (const [index, url] of geminiFallbackUrls.entries()) {
   const parsedUrl = z.url().safeParse(url);
   if (!parsedUrl.success) {
-    logger.error(`❌ Invalid GEMINI_API_FALLBACK_URLS entry: ${url}`);
+    logger.error(`❌ Invalid GEMINI_API_FALLBACK_URLS entry at position ${index + 1}`);
     process.exit(1);
   }
 }

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -54,6 +54,14 @@ for (const [index, url] of geminiFallbackUrls.entries()) {
     logger.error(`❌ Invalid GEMINI_API_FALLBACK_URLS entry at position ${index + 1}`);
     process.exit(1);
   }
+
+  if (
+    !["development", "test"].includes(parsedEnv.data.NODE_ENV) &&
+    new URL(url).protocol !== "https:"
+  ) {
+    logger.error(`❌ GEMINI_API_FALLBACK_URLS entry at position ${index + 1} must use HTTPS`);
+    process.exit(1);
+  }
 }
 
 export const env = {

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -43,4 +43,20 @@ if (!parsedEnv.success) {
   process.exit(1);
 }
 
-export const env = parsedEnv.data;
+const geminiFallbackUrls = (process.env.GEMINI_API_FALLBACK_URLS ?? "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+for (const url of geminiFallbackUrls) {
+  const parsedUrl = z.url().safeParse(url);
+  if (!parsedUrl.success) {
+    logger.error(`❌ Invalid GEMINI_API_FALLBACK_URLS entry: ${url}`);
+    process.exit(1);
+  }
+}
+
+export const env = {
+  ...parsedEnv.data,
+  GEMINI_API_FALLBACK_URLS: geminiFallbackUrls,
+};

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -289,6 +289,8 @@ async function callGemini(
 
     throw lastError;
   }
+
+  // Defensive safeguard: the retry loop above should always exit via return or throw.
   throw new Error("callGemini: exhausted retries without result");
 }
 

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -26,7 +26,7 @@ export class GeminiTemporaryError extends Error {
 }
 
 function getGeminiApiUrls(): string[] {
-  return [env.GEMINI_API_URL, ...env.GEMINI_API_FALLBACK_URLS];
+  return [...new Set([env.GEMINI_API_URL, ...env.GEMINI_API_FALLBACK_URLS])];
 }
 
 function isRetriableGeminiError(error: unknown): boolean {

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -11,8 +11,15 @@ import { sanitizeJsonString } from "../../shared/utils/json.js";
 import { GeminiRateLimitError } from "../ai-agents/gemini-client.js";
 import { langInstruction } from "../../shared/utils/ai-prompt.js";
 
-class GeminiTemporaryError extends Error {
-  constructor(message: string) {
+export type GeminiTemporaryErrorReason = "timeout" | "network" | "upstream";
+
+export class GeminiTemporaryError extends Error {
+  readonly code = "GEMINI_TEMPORARY";
+
+  constructor(
+    message: string,
+    readonly reason: GeminiTemporaryErrorReason
+  ) {
     super(message);
     this.name = "GeminiTemporaryError";
   }
@@ -196,10 +203,13 @@ async function callGeminiOnce(
     });
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
-      throw new GeminiTemporaryError(`Gemini API timeout after ${GEMINI_TIMEOUT_MS}ms`);
+      throw new GeminiTemporaryError(`Gemini API timeout after ${GEMINI_TIMEOUT_MS}ms`, "timeout");
     }
     if (error instanceof TypeError || (error instanceof Error && error.message.includes("fetch"))) {
-      throw new GeminiTemporaryError(`Gemini API request failed: ${getErrorMessage(error)}`);
+      throw new GeminiTemporaryError(
+        `Gemini API request failed: ${getErrorMessage(error)}`,
+        "network"
+      );
     }
     throw error;
   } finally {
@@ -214,7 +224,8 @@ async function callGeminiOnce(
 
   if ([502, 503, 504].includes(response.status)) {
     throw new GeminiTemporaryError(
-      `Gemini API temporary error: ${response.status} ${response.statusText}`
+      `Gemini API temporary error: ${response.status} ${response.statusText}`,
+      "upstream"
     );
   }
 

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -26,6 +26,10 @@ function isRetriableGeminiError(error: unknown): boolean {
   return error instanceof GeminiRateLimitError || error instanceof GeminiTemporaryError;
 }
 
+function isFailoverGeminiError(error: unknown): boolean {
+  return error instanceof GeminiTemporaryError;
+}
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -194,6 +198,9 @@ async function callGeminiOnce(
     if (error instanceof Error && error.name === "AbortError") {
       throw new GeminiTemporaryError(`Gemini API timeout after ${GEMINI_TIMEOUT_MS}ms`);
     }
+    if (error instanceof TypeError || (error instanceof Error && error.message.includes("fetch"))) {
+      throw new GeminiTemporaryError(`Gemini API request failed: ${getErrorMessage(error)}`);
+    }
     throw error;
   } finally {
     clearTimeout(timeout);
@@ -246,6 +253,10 @@ async function callGemini(
 
         if (!isRetriableGeminiError(error)) {
           throw error;
+        }
+
+        if (!isFailoverGeminiError(error)) {
+          break;
         }
 
         if (urlIndex < apiUrls.length - 1) {

--- a/src/modules/habits/habit-planner.ts
+++ b/src/modules/habits/habit-planner.ts
@@ -11,6 +11,25 @@ import { sanitizeJsonString } from "../../shared/utils/json.js";
 import { GeminiRateLimitError } from "../ai-agents/gemini-client.js";
 import { langInstruction } from "../../shared/utils/ai-prompt.js";
 
+class GeminiTemporaryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GeminiTemporaryError";
+  }
+}
+
+function getGeminiApiUrls(): string[] {
+  return [env.GEMINI_API_URL, ...env.GEMINI_API_FALLBACK_URLS];
+}
+
+function isRetriableGeminiError(error: unknown): boolean {
+  return error instanceof GeminiRateLimitError || error instanceof GeminiTemporaryError;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 type PlannerInput = {
   name: string;
   targetSkill?: string;
@@ -143,6 +162,7 @@ const LIGHT_PLAN_RESPONSE_SCHEMA = {
 
 async function callGeminiOnce(
   apiKey: string,
+  apiUrl: string,
   prompt: string,
   maxOutputTokens: number,
   isFull: boolean
@@ -152,7 +172,7 @@ async function callGeminiOnce(
 
   let response: Response;
   try {
-    response = await fetch(env.GEMINI_API_URL, {
+    response = await fetch(apiUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -172,7 +192,7 @@ async function callGeminiOnce(
     });
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Gemini API timeout after ${GEMINI_TIMEOUT_MS}ms`);
+      throw new GeminiTemporaryError(`Gemini API timeout after ${GEMINI_TIMEOUT_MS}ms`);
     }
     throw error;
   } finally {
@@ -182,6 +202,12 @@ async function callGeminiOnce(
   if (response.status === 429) {
     throw new GeminiRateLimitError(
       `Gemini API rate limit: ${response.status} ${response.statusText}`
+    );
+  }
+
+  if ([502, 503, 504].includes(response.status)) {
+    throw new GeminiTemporaryError(
+      `Gemini API temporary error: ${response.status} ${response.statusText}`
     );
   }
 
@@ -206,21 +232,40 @@ async function callGemini(
 ): Promise<string> {
   const apiKey = env.GEMINI_API_KEY;
   if (!apiKey) throw new Error("GEMINI_API_KEY is not configured");
+  const apiUrls = getGeminiApiUrls();
+
+  let lastError: unknown;
 
   for (let attempt = 0; attempt <= GEMINI_MAX_RETRIES; attempt++) {
-    try {
-      return await callGeminiOnce(apiKey, prompt, maxOutputTokens, isFull);
-    } catch (error) {
-      if (error instanceof GeminiRateLimitError && attempt < GEMINI_MAX_RETRIES) {
-        const delay = GEMINI_RETRY_BASE_MS * 2 ** attempt;
-        logger.warn(
-          `[habit-planner] Rate limited, retrying in ${delay}ms (attempt ${attempt + 1}/${GEMINI_MAX_RETRIES})`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        continue;
+    for (let urlIndex = 0; urlIndex < apiUrls.length; urlIndex++) {
+      const apiUrl = apiUrls[urlIndex];
+      try {
+        return await callGeminiOnce(apiKey, apiUrl, prompt, maxOutputTokens, isFull);
+      } catch (error) {
+        lastError = error;
+
+        if (!isRetriableGeminiError(error)) {
+          throw error;
+        }
+
+        if (urlIndex < apiUrls.length - 1) {
+          logger.warn(
+            `[habit-planner] ${getErrorMessage(error)}; trying fallback Gemini endpoint ${urlIndex + 2}/${apiUrls.length}`
+          );
+        }
       }
-      throw error;
     }
+
+    if (attempt < GEMINI_MAX_RETRIES && isRetriableGeminiError(lastError)) {
+      const delay = GEMINI_RETRY_BASE_MS * 2 ** attempt;
+      logger.warn(
+        `[habit-planner] ${getErrorMessage(lastError)}; retrying in ${delay}ms (attempt ${attempt + 1}/${GEMINI_MAX_RETRIES + 1})`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      continue;
+    }
+
+    throw lastError;
   }
   throw new Error("callGemini: exhausted retries without result");
 }

--- a/src/modules/habits/habits.service.ts
+++ b/src/modules/habits/habits.service.ts
@@ -19,13 +19,14 @@ import type {
   RegeneratePlanInput,
   UpdateHabitInput,
 } from "./habits.types.js";
-import { generateHabitPlan } from "./habit-planner.js";
+import { generateHabitPlan, GeminiTemporaryError } from "./habit-planner.js";
 import type { HabitPlan } from "./habit-plan.schema.js";
 import { MAX_ACTIVE_HABITS } from "../../shared/constants.js";
 import { getTodayUTCString } from "../../shared/utils/date.js";
 import { computeCurrentDay, computeStreak } from "../../shared/utils/habit-math.js";
 import { nextAiRequestCount } from "../../shared/utils/ai-rate-limit.js";
 import { assertAiRateLimit } from "../../shared/guards/ai-rate-limit.guard.js";
+import { GeminiRateLimitError } from "../ai-agents/gemini-client.js";
 
 export type HabitWithStats = Habit & {
   streak: number;
@@ -46,6 +47,20 @@ function enrichHabit(habit: Habit, logs: HabitLog[]): HabitWithStats {
 function toHabitPlannerError(error: unknown): AppError {
   if (error instanceof AppError) {
     return error;
+  }
+
+  if (error instanceof GeminiRateLimitError) {
+    return new TooManyRequestsError("AI service is busy. Please wait a moment and try again.");
+  }
+
+  if (error instanceof GeminiTemporaryError) {
+    if (error.reason === "timeout") {
+      return new ServiceUnavailableError("AI request timed out. Please try again.");
+    }
+
+    return new ServiceUnavailableError(
+      "AI service is temporarily unavailable. Please try again in a moment."
+    );
   }
 
   if (error instanceof Error) {

--- a/src/modules/habits/habits.service.ts
+++ b/src/modules/habits/habits.service.ts
@@ -229,6 +229,8 @@ export function createHabitsService({
           (await habitsRepo.update(habit.id, userId, { planStatus: "failed" })) ?? habit;
         const plannerError = toHabitPlannerError(err);
         if (plannerError instanceof TooManyRequestsError) {
+          // Suppress rate-limit after creation to avoid client retries duplicating habits.
+          // Users can safely retry plan generation later through regeneratePlan.
           logger.warn({ err }, "[habit-planner] createWithPlan rate-limited after habit creation");
           return enrichHabit(updated, []);
         }

--- a/src/modules/habits/habits.service.ts
+++ b/src/modules/habits/habits.service.ts
@@ -228,7 +228,10 @@ export function createHabitsService({
         const updated =
           (await habitsRepo.update(habit.id, userId, { planStatus: "failed" })) ?? habit;
         const plannerError = toHabitPlannerError(err);
-        if (plannerError instanceof TooManyRequestsError) throw plannerError;
+        if (plannerError instanceof TooManyRequestsError) {
+          logger.warn({ err }, "[habit-planner] createWithPlan rate-limited after habit creation");
+          return enrichHabit(updated, []);
+        }
         logger.error({ err }, "[habit-planner] generateHabitPlan failed");
         return enrichHabit(updated, []);
       }

--- a/src/modules/habits/habits.service.ts
+++ b/src/modules/habits/habits.service.ts
@@ -4,7 +4,9 @@ import type { UserProfilesRepository } from "../users/user-profiles.repository.j
 import type { Habit, HabitLog } from "../../core/database/schema/index.js";
 import { logger } from "../../core/config/logger.js";
 import {
+  AppError,
   NotFoundError,
+  ServiceUnavailableError,
   TooManyRequestsError,
   UnprocessableError,
 } from "../../shared/errors/index.js";
@@ -39,6 +41,32 @@ function enrichHabit(habit: Habit, logs: HabitLog[]): HabitWithStats {
     currentDay: computeCurrentDay(habit.startDate),
     completedToday: logs.some((l) => l.logDate === todayStr && l.completed),
   };
+}
+
+function toHabitPlannerError(error: unknown): AppError {
+  if (error instanceof AppError) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    const normalizedMessage = error.message.toLowerCase();
+
+    if (normalizedMessage.includes("rate limit")) {
+      return new TooManyRequestsError("AI service is busy. Please wait a moment and try again.");
+    }
+
+    if (normalizedMessage.includes("timeout")) {
+      return new ServiceUnavailableError("AI request timed out. Please try again.");
+    }
+
+    if (normalizedMessage.includes("not configured")) {
+      return new ServiceUnavailableError("AI service is not available at the moment.");
+    }
+  }
+
+  return new ServiceUnavailableError(
+    "AI service is temporarily unavailable. Please try again in a moment."
+  );
 }
 
 type HabitsServiceDeps = {
@@ -96,18 +124,23 @@ export function createHabitsService({
         (input.targetSkill as Parameters<typeof deriveHabitMode>[0]) ?? "general"
       );
       const uiLanguage = profile?.uiLanguage ?? "pt-BR";
-      return generateHabitPlan(
-        {
-          name: input.name,
-          targetSkill: input.targetSkill ?? undefined,
-          painPoints: input.painPoints,
-          availableMinutes: input.availableMinutes,
-          level: input.level,
-          uiLanguage,
-          feedbackOnPlan: input.feedbackOnPlan ?? undefined,
-        },
-        mode
-      );
+      try {
+        return await generateHabitPlan(
+          {
+            name: input.name,
+            targetSkill: input.targetSkill ?? undefined,
+            painPoints: input.painPoints,
+            availableMinutes: input.availableMinutes,
+            level: input.level,
+            uiLanguage,
+            feedbackOnPlan: input.feedbackOnPlan ?? undefined,
+          },
+          mode
+        );
+      } catch (err) {
+        logger.error({ err }, "[habit-planner] previewPlan failed");
+        throw toHabitPlannerError(err);
+      }
     },
 
     async create(userId: string, input: CreateHabitInput): Promise<HabitWithStats> {
@@ -179,7 +212,8 @@ export function createHabitsService({
       } catch (err) {
         const updated =
           (await habitsRepo.update(habit.id, userId, { planStatus: "failed" })) ?? habit;
-        if (err instanceof TooManyRequestsError) throw err;
+        const plannerError = toHabitPlannerError(err);
+        if (plannerError instanceof TooManyRequestsError) throw plannerError;
         logger.error({ err }, "[habit-planner] generateHabitPlan failed");
         return enrichHabit(updated, []);
       }
@@ -227,7 +261,9 @@ export function createHabitsService({
       } catch (err) {
         const updated =
           (await habitsRepo.update(habitId, userId, { planStatus: "failed" })) ?? habit;
-        if (err instanceof TooManyRequestsError) throw err;
+        const plannerError = toHabitPlannerError(err);
+        if (plannerError instanceof TooManyRequestsError) throw plannerError;
+        logger.error({ err }, "[habit-planner] regeneratePlan failed");
         return enrichHabit(updated, logs);
       }
     },

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -52,3 +52,9 @@ export class TooManyRequestsError extends AppError {
     super(429, "TOO_MANY_REQUESTS", message);
   }
 }
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message: string) {
+    super(503, "SERVICE_UNAVAILABLE", message);
+  }
+}

--- a/tests/unit/habit-planner.test.ts
+++ b/tests/unit/habit-planner.test.ts
@@ -183,6 +183,47 @@ describe("generateHabitPlan — failures", () => {
     expect(mockFetch.mock.calls[1]?.[0]).toBe("https://gemini-fallback.test");
   });
 
+  it("retries rate-limit responses without switching to fallback endpoints", async () => {
+    jest.useFakeTimers();
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 429, statusText: "Too Many Requests" })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: "Internal Server Error" });
+
+    try {
+      const planPromise = generateHabitPlan(
+        { name: "Inglês", painPoints: ["pronuncia"], availableMinutes: 30, level: "beginner" },
+        "skill-building"
+      );
+      const rejection = expect(planPromise).rejects.toThrow(
+        "Gemini API error: 500 Internal Server Error"
+      );
+
+      await jest.advanceTimersByTimeAsync(5_000);
+      await rejection;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls.every((call) => call[0] === "https://gemini.test")).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("falls back when fetch fails before receiving an HTTP response", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(makeGeminiResponse(FULL_PLAN));
+
+    const plan = await generateHabitPlan(
+      { name: "Inglês", painPoints: ["pronuncia"], availableMinutes: 30, level: "beginner" },
+      "skill-building"
+    );
+
+    expect(plan.plan_type).toBe("full");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://gemini.test");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://gemini-fallback.test");
+  });
+
   it("throws ZodError when Gemini returns invalid JSON structure", async () => {
     const invalidPlan = JSON.stringify({ schema_version: 2, plan_type: "full" }); // missing required fields
     mockFetch.mockResolvedValue(makeGeminiResponse(invalidPlan));

--- a/tests/unit/habit-planner.test.ts
+++ b/tests/unit/habit-planner.test.ts
@@ -4,6 +4,7 @@ jest.mock("@/core/config/env.js", () => ({
   env: {
     GEMINI_API_KEY: "test-gemini-key",
     GEMINI_API_URL: "https://gemini.test",
+    GEMINI_API_FALLBACK_URLS: ["https://gemini-fallback.test"],
     JWT_REFRESH_EXPIRES: "7d",
   },
 }));
@@ -155,15 +156,31 @@ describe("generateHabitPlan — failures", () => {
     ).rejects.toThrow();
   });
 
-  it("throws when Gemini API returns non-ok status", async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: "Service Unavailable" });
+  it("throws when Gemini API returns a non-retriable non-ok status", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: "Internal Server Error" });
 
     await expect(
       generateHabitPlan(
         { name: "Inglês", painPoints: ["pronuncia"], availableMinutes: 30, level: "beginner" },
         "skill-building"
       )
-    ).rejects.toThrow("Gemini API error: 503");
+    ).rejects.toThrow("Gemini API error: 500 Internal Server Error");
+  });
+
+  it("falls back to the secondary Gemini endpoint on temporary upstream failure", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" })
+      .mockResolvedValueOnce(makeGeminiResponse(FULL_PLAN));
+
+    const plan = await generateHabitPlan(
+      { name: "Inglês", painPoints: ["pronuncia"], availableMinutes: 30, level: "beginner" },
+      "skill-building"
+    );
+
+    expect(plan.plan_type).toBe("full");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://gemini.test");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://gemini-fallback.test");
   });
 
   it("throws ZodError when Gemini returns invalid JSON structure", async () => {

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -127,11 +127,11 @@ describe("previewPlan", () => {
         availableMinutes: 30,
         level: "beginner",
       })
-    ).rejects.toEqual(
-      expect.objectContaining({
-        message: "AI service is temporarily unavailable. Please try again in a moment.",
-      })
-    );
+    ).rejects.toMatchObject({
+      message: "AI service is temporarily unavailable. Please try again in a moment.",
+      statusCode: 503,
+      code: "SERVICE_UNAVAILABLE",
+    });
   });
 
   it("throws ServiceUnavailableError when Gemini times out", async () => {

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -26,7 +26,7 @@ jest.mock("@/modules/habits/habit-planner.js", () => ({
   },
 }));
 
-import { generateHabitPlan } from "@/modules/habits/habit-planner.js";
+import { generateHabitPlan, GeminiTemporaryError } from "@/modules/habits/habit-planner.js";
 const mockGeneratePlan = generateHabitPlan as jest.MockedFunction<typeof generateHabitPlan>;
 
 const FULL_PLAN = {
@@ -164,7 +164,9 @@ describe("previewPlan", () => {
 
   it("throws ServiceUnavailableError when Gemini times out", async () => {
     const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
-    mockGeneratePlan.mockRejectedValue(new Error("Gemini API timeout after 10000ms"));
+    mockGeneratePlan.mockRejectedValue(
+      new GeminiTemporaryError("Gemini API timeout after 10000ms", "timeout")
+    );
 
     const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
 
@@ -207,6 +209,22 @@ describe("createWithPlan", () => {
     const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
     const result = await service.createWithPlan("user-id-1", planInput);
 
+    expect(habitsRepo.update).toHaveBeenCalledWith(
+      mockHabit.id,
+      "user-id-1",
+      expect.objectContaining({ planStatus: "failed" })
+    );
+    expect(result.planStatus).toBe("failed");
+  });
+
+  it("returns a failed habit instead of rethrowing when Gemini is rate-limited after creation", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(new Error("Gemini API rate limit: 429 Too Many Requests"));
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+    const result = await service.createWithPlan("user-id-1", planInput);
+
+    expect(habitsRepo.create).toHaveBeenCalledTimes(1);
     expect(habitsRepo.update).toHaveBeenCalledWith(
       mockHabit.id,
       "user-id-1",

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -13,6 +13,17 @@ import type { Habit } from "@/core/database/schema/index.js";
 
 jest.mock("@/modules/habits/habit-planner.js", () => ({
   generateHabitPlan: jest.fn(),
+  GeminiTemporaryError: class GeminiTemporaryError extends Error {
+    code = "GEMINI_TEMPORARY";
+
+    constructor(
+      message: string,
+      public reason: "timeout" | "network" | "upstream"
+    ) {
+      super(message);
+      this.name = "GeminiTemporaryError";
+    }
+  },
 }));
 
 import { generateHabitPlan } from "@/modules/habits/habit-planner.js";
@@ -132,6 +143,23 @@ describe("previewPlan", () => {
       statusCode: 503,
       code: "SERVICE_UNAVAILABLE",
     });
+  });
+
+  it("throws TooManyRequestsError when Gemini is rate-limited", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(new Error("Gemini API rate limit: 429 Too Many Requests"));
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+
+    await expect(
+      service.previewPlan("user-id-1", {
+        name: "Inglês",
+        targetSkill: "en-US",
+        painPoints: ["pronuncia"],
+        availableMinutes: 30,
+        level: "beginner",
+      })
+    ).rejects.toThrow(TooManyRequestsError);
   });
 
   it("throws ServiceUnavailableError when Gemini times out", async () => {

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -1,6 +1,11 @@
 import { createHabitsService } from "@/modules/habits/habits.service.js";
 import { MAX_ACTIVE_HABITS } from "@/shared/constants.js";
-import { NotFoundError, TooManyRequestsError, UnprocessableError } from "@/shared/errors/index.js";
+import {
+  NotFoundError,
+  ServiceUnavailableError,
+  TooManyRequestsError,
+  UnprocessableError,
+} from "@/shared/errors/index.js";
 import type { HabitsRepository } from "@/modules/habits/habits.repository.js";
 import type { HabitLogsRepository } from "@/modules/habits/habit-logs.repository.js";
 import type { UserProfilesRepository } from "@/modules/users/user-profiles.repository.js";
@@ -103,6 +108,48 @@ const planInput = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe("previewPlan", () => {
+  it("throws a friendly service-unavailable error when Gemini is down", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(
+      new Error("Gemini API temporary error: 503 Service Unavailable")
+    );
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+
+    await expect(
+      service.previewPlan("user-id-1", {
+        name: "Inglês",
+        targetSkill: "en-US",
+        painPoints: ["pronuncia"],
+        availableMinutes: 30,
+        level: "beginner",
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        message: "AI service is temporarily unavailable. Please try again in a moment.",
+      })
+    );
+  });
+
+  it("throws ServiceUnavailableError when Gemini times out", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(new Error("Gemini API timeout after 10000ms"));
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+
+    await expect(
+      service.previewPlan("user-id-1", {
+        name: "Inglês",
+        targetSkill: "en-US",
+        painPoints: ["pronuncia"],
+        availableMinutes: 30,
+        level: "beginner",
+      })
+    ).rejects.toThrow(ServiceUnavailableError);
+  });
 });
 
 describe("createWithPlan", () => {

--- a/tests/unit/habits.service.test.ts
+++ b/tests/unit/habits.service.test.ts
@@ -180,6 +180,44 @@ describe("previewPlan", () => {
       })
     ).rejects.toThrow(ServiceUnavailableError);
   });
+
+  it("throws ServiceUnavailableError when Gemini has a network failure", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(
+      new GeminiTemporaryError("Gemini API request failed: fetch failed", "network")
+    );
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+
+    await expect(
+      service.previewPlan("user-id-1", {
+        name: "Inglês",
+        targetSkill: "en-US",
+        painPoints: ["pronuncia"],
+        availableMinutes: 30,
+        level: "beginner",
+      })
+    ).rejects.toThrow(ServiceUnavailableError);
+  });
+
+  it("throws ServiceUnavailableError when Gemini upstream is temporarily unavailable", async () => {
+    const { habitsRepo, habitLogsRepo, userProfilesRepo } = makeRepos();
+    mockGeneratePlan.mockRejectedValue(
+      new GeminiTemporaryError("Gemini API temporary error: 503 Service Unavailable", "upstream")
+    );
+
+    const service = createHabitsService({ habitsRepo, habitLogsRepo, userProfilesRepo });
+
+    await expect(
+      service.previewPlan("user-id-1", {
+        name: "Inglês",
+        targetSkill: "en-US",
+        painPoints: ["pronuncia"],
+        availableMinutes: 30,
+        level: "beginner",
+      })
+    ).rejects.toThrow(ServiceUnavailableError);
+  });
 });
 
 describe("createWithPlan", () => {


### PR DESCRIPTION
## Summary
- convert Gemini planner failures into user-facing service-unavailable messages instead of leaking raw upstream errors
- add configurable Gemini fallback endpoints for temporary upstream failures during habit plan generation
- cover the new planner error mapping and fallback flow with unit tests

## Validation
- `npx jest tests/unit/habit-planner.test.ts tests/unit/habits.service.test.ts --runInBand`
- `npm run typecheck`
- full pre-commit hooks passed: `test:unit`, `test:integration`, `test:e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Suporte a endpoints alternativos configuráveis para a API Gemini; fallbacks validados e exportados na configuração.
  * Novo tipo de erro para falhas temporárias e um erro de Serviço Indisponível padronizado.

* **Correções de Bugs**
  * Em ambientes não dev/test, URL principal e fallbacks exigem HTTPS.
  * Separação clara entre retry e failover, com backoff e normalização de erros; serviços retornam hábito como "failed" em rate-limit previsíveis.

* **Testes**
  * Cobertura adicionada para failover, retries, falhas de rede e mapeamento de erros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->