### PR TITLE
fix: hide swagger docs in production

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,9 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(jwtPlugin);
   await fastify.register(rateLimitPlugin);
   await fastify.register(cookiePlugin);
-  await fastify.register(swaggerPlugin);
+  if (env.NODE_ENV !== "production") {
+    await fastify.register(swaggerPlugin);
+  }
 
   await fastify.register(healthRoutes);
   await fastify.register(authRoutes, { prefix: "/api" });


### PR DESCRIPTION
## Summary
- `/documentation` (Swagger UI) era registrado sem checagem de ambiente, ficando exposto publicamente em produção
- Gate por `NODE_ENV !== "production"` — disponível em dev/homolog, escondido em prod

## Contexto
Achado durante a migração real de produção pro EC2+RDS (2026-07-25). O schema de env já prevê `NODE_ENV=homolog`, então isso já cobre a ideia de manter docs visíveis num ambiente de homologação.

## Test plan
- [x] Testes unitários (247) passando
- [x] Testes de integração passando (local, via docker-compose)
- [ ] Após merge + deploy manual na EC2: confirmar que `https://api.insidemymind.tech/documentation` retorna 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * A documentação interativa da API agora é disponibilizada apenas em ambientes que não são de produção.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->