### PR TITLE
ci: remove dead CodeRabbit ai-pr-reviewer job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,29 +100,11 @@ jobs:
         run: npm run test:integration
 
   # ─────────────────────────────────────────────────────────────
-  # Step 3: CodeRabbit — só em PRs, só se Step 2 passar
-  # continue-on-error: true → falha do CodeRabbit é aviso, não bloqueio
-  # ─────────────────────────────────────────────────────────────
-  ai_review:
-    name: "Step 3: AI Code Review (CodeRabbit)"
-    needs: tests
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.tests.result == 'success'
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: CodeRabbit Review
-        continue-on-error: true
-        uses: coderabbitai/ai-pr-reviewer@1.16.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
+  # CodeRabbit já roda sozinho via GitHub App instalado no repo —
+  # não precisa de step aqui. (Removido: job "ai_review" chamava a
+  # action coderabbitai/ai-pr-reviewer, descontinuada pela CodeRabbit.)
   # ─────────────────────────────────────────────────────────────
   # Quality Gate — status check obrigatório para branch protection
-  # NÃO depende do ai_review: CodeRabbit nunca bloqueia merge
   # ─────────────────────────────────────────────────────────────
   quality_gate:
     name: "Quality Gate"


### PR DESCRIPTION
## Summary
- Removido o job `ai_review` do `ci.yml` — chamava `coderabbitai/ai-pr-reviewer@1.16.2`, action descontinuada que não resolve mais (`Error: Unable to resolve action`), fazendo esse step falhar em toda PR
- O review de IA de verdade já roda via o **GitHub App** da CodeRabbit instalado no repo — não depende de nenhum step do workflow, continua funcionando igual
- `Quality Gate` nunca dependeu desse job (comentário no próprio arquivo já dizia isso), então merge requirement não muda

## Por que isso e não só "consertar" o step
A action não existe mais pra resolver versão nenhuma dela — não tem config que arrume isso, o pacote foi descontinuado pela própria CodeRabbit quando migraram todo mundo pro modelo de GitHub App.

## Test plan
- [x] YAML válido
- [ ] Confirmar que a pipeline fica 100% verde nesse PR (sem o step fantasma falhando)