### PR TITLE
fix: remove environment from cd-ec2.yml, breaks OIDC sub claim

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -18,9 +18,11 @@ jobs:
   deploy:
     name: "Deploy to EC2 via SSM"
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://api.insidemymind.tech
+    # Sem "environment:" de propósito — isso muda o claim `sub` do token OIDC
+    # de repo:OWNER/REPO:ref:refs/heads/main para
+    # repo:OWNER/REPO:environment:<nome>, o que não bate com o trust policy
+    # do imm-github-oidc-role (escopado por branch/ref) e derruba o
+    # sts:AssumeRoleWithWebIdentity com AccessDenied.
 
     steps:
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## Summary
Primeiro deploy real via SSM falhou: `AccessDenied` no `sts:AssumeRoleWithWebIdentity`. Causa: o job tinha `environment: production`, o que muda o claim `sub` do token OIDC de `repo:OWNER/REPO:ref:refs/heads/main` pra `repo:OWNER/REPO:environment:production` — não bate com a trust policy do `imm-github-oidc-role` (escopada por branch/ref, decisão do Módulo 1).

`environment:` era só decorativo (badge de URL), copiado do `cd-railway.yml` antigo, onde era inofensivo porque aquele workflow nunca usava OIDC.

## Test plan
- [x] Unit + integration passando
- [ ] Confirmar deploy real na EC2 depois desse merge chegar em `main`