### PR TITLE
fix: OIDC sub claim mismatch blocking EC2 deploy

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -18,9 +18,11 @@ jobs:
   deploy:
     name: "Deploy to EC2 via SSM"
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://api.insidemymind.tech
+    # Sem "environment:" de propósito — isso muda o claim `sub` do token OIDC
+    # de repo:OWNER/REPO:ref:refs/heads/main para
+    # repo:OWNER/REPO:environment:<nome>, o que não bate com o trust policy
+    # do imm-github-oidc-role (escopado por branch/ref) e derruba o
+    # sts:AssumeRoleWithWebIdentity com AccessDenied.
 
     steps:
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
Corrige o AccessDenied do primeiro deploy real (environment: no job mudava o claim sub do OIDC). Ver #148.