### PR TITLE
fix: run SSM deploy commands as ec2-user, not root

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -39,7 +39,7 @@ jobs:
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
             --comment "imm-api deploy from ${{ github.sha }}" \
-            --parameters 'commands=["cd /home/ec2-user/imm-api", "git fetch --quiet", "git reset --hard origin/main", "npm ci", "npm run build", "pm2 restart imm-api"]' \
+            --parameters "commands=[\"sudo -u ec2-user bash -lc 'cd /home/ec2-user/imm-api && git fetch --quiet && git reset --hard origin/main && npm ci && npm run build && pm2 restart imm-api'\"]" \
             --query "Command.CommandId" --output text)
           echo "Command ID: $COMMAND_ID"
 


### PR DESCRIPTION
Segundo problema real do primeiro deploy (depois do fix de OIDC do #148): SSM roda como root, mas repo/PM2 são do ec2-user. `git` recusava (dubious ownership) e o `pm2 restart` batia num daemon root novo que nunca viu o processo. Wrap com `sudo -u ec2-user bash -lc '...'`.