### PR TITLE
fix: replace ssm wait command-executed with longer custom polling

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -43,11 +43,19 @@ jobs:
             --query "Command.CommandId" --output text)
           echo "Command ID: $COMMAND_ID"
 
-          aws ssm wait command-executed --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" || true
-
-          STATUS=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
-            --query "Status" --output text)
+          # aws ssm wait command-executed desiste em ~100s (5s x 20 tentativas,
+          # fixo no botocore) — npm ci + build numa t3.micro pode levar mais
+          # que isso. Polling próprio, até 8 min.
+          for i in $(seq 1 48); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+              --query "Status" --output text)
+            echo "Status ($i/48): $STATUS"
+            case "$STATUS" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 10
+          done
 
           echo "--- stdout ---"
           aws ssm get-command-invocation \


### PR DESCRIPTION
Terceiro problema real do deploy: o waiter padrão do `aws ssm wait command-executed` desiste em ~100s (fixo no botocore), mas `npm ci`+build na t3.micro pode levar mais — o workflow reportava falha com o comando ainda `InProgress` de verdade. Troca por polling próprio, até 8min.