### PR TITLE
ci: add CD workflow for the presigned-url Lambda

### DIFF
--- a/.github/workflows/cd-lambda-presigned-url.yml
+++ b/.github/workflows/cd-lambda-presigned-url.yml
@@ -10,6 +10,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: deploy-lambda-presigned-url
+  cancel-in-progress: false
+
 defaults:
   run:
     working-directory: lambda/presigned-url
@@ -18,24 +22,39 @@ jobs:
   deploy:
     name: "Deploy Lambda (imm-presigned-url)"
     runs-on: ubuntu-latest
+    # workflow_dispatch não restringe branch por padrão — sem essa guarda,
+    # um disparo manual a partir de qualquer branch (inclusive não revisada)
+    # subiria pra produção pulando o PR inteiro.
+    if: github.ref == 'refs/heads/main'
     # Sem "environment:" de propósito — muda o claim sub do token OIDC e
     # quebra o trust policy do imm-github-oidc-role (mesmo motivo do cd-ec2.yml).
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::431715654897:role/imm-github-oidc-role
-          aws-region: us-east-1
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Install deps and package
         run: |
           npm ci --omit=dev
           zip -r function.zip .
 
+      # Credenciais AWS entram só agora — depois do npm ci, não antes.
+      # npm ci roda scripts de terceiros; não faz sentido ter credencial
+      # AWS viva no ambiente enquanto isso acontece.
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::431715654897:role/imm-github-oidc-role
+          aws-region: us-east-1
+
       - name: Deploy to Lambda
         run: |
           aws lambda update-function-code \
             --function-name imm-presigned-url \
             --zip-file fileb://function.zip
+          aws lambda wait function-updated \
+            --function-name imm-presigned-url

--- a/.github/workflows/cd-lambda-presigned-url.yml
+++ b/.github/workflows/cd-lambda-presigned-url.yml
@@ -1,0 +1,41 @@
+name: CD Lambda — presigned-url
+
+on:
+  push:
+    branches: [main]
+    paths: ["lambda/presigned-url/**"]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    working-directory: lambda/presigned-url
+
+jobs:
+  deploy:
+    name: "Deploy Lambda (imm-presigned-url)"
+    runs-on: ubuntu-latest
+    # Sem "environment:" de propósito — muda o claim sub do token OIDC e
+    # quebra o trust policy do imm-github-oidc-role (mesmo motivo do cd-ec2.yml).
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::431715654897:role/imm-github-oidc-role
+          aws-region: us-east-1
+
+      - name: Install deps and package
+        run: |
+          npm ci --omit=dev
+          zip -r function.zip .
+
+      - name: Deploy to Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name imm-presigned-url \
+            --zip-file fileb://function.zip


### PR DESCRIPTION
## Summary
- Adiciona `.github/workflows/cd-lambda-presigned-url.yml`, disparado por push em `main` mudando `lambda/presigned-url/**`
- Reaproveita a role de CI que já existe (`imm-github-oidc-role`, mesma trust policy OIDC do `cd-ec2.yml`) — sem criar role nova
- `update-function-code` é síncrono/atômico, então sem a complexidade de polling que o `cd-ec2.yml` precisa pro SSM

## Test plan
- [ ] Merge, depois adicionar código em `lambda/presigned-url/` numa PR seguinte e confirmar que o workflow dispara e o `aws lambda update-function-code` conclui com sucesso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adicionado um processo automatizado para publicar atualizações do serviço de geração de URLs pré-assinadas.
  - O fluxo pode ser executado automaticamente após alterações relevantes ou acionado manualmente quando necessário.
  - As publicações passam a ocorrer de forma mais consistente, reduzindo etapas manuais e possíveis erros durante atualizações.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->