### PR TITLE
feat: implement presigned-url Lambda handler with JWT verification

### DIFF
--- a/.github/workflows/cd-lambda-presigned-url.yml
+++ b/.github/workflows/cd-lambda-presigned-url.yml
@@ -38,10 +38,15 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install deps and package
+      - name: Install and test
+        run: |
+          npm ci
+          npm test
+
+      - name: Package
         run: |
           npm ci --omit=dev
-          zip -r function.zip .
+          zip -r function.zip . -x "*.test.mjs"
 
       # Credenciais AWS entram só agora — depois do npm ci, não antes.
       # npm ci roda scripts de terceiros; não faz sentido ter credencial

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,32 @@ jobs:
         run: npm run test:integration
 
   # ─────────────────────────────────────────────────────────────
+  # Lambda presigned-url — pasta própria, package.json próprio, fora do
+  # escopo de lint/test do imm-api raiz. Sem isso, index.test.mjs só roda
+  # se alguém lembrar de rodar à mão.
+  # ─────────────────────────────────────────────────────────────
+  lambda_presigned_url_tests:
+    name: "Lambda: presigned-url tests"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lambda/presigned-url
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+  # ─────────────────────────────────────────────────────────────
   # CodeRabbit já roda sozinho via GitHub App instalado no repo —
   # não precisa de step aqui. (Removido: job "ai_review" chamava a
   # action coderabbitai/ai-pr-reviewer, descontinuada pela CodeRabbit.)
@@ -108,7 +134,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   quality_gate:
     name: "Quality Gate"
-    needs: [code_quality, tests]
+    needs: [code_quality, tests, lambda_presigned_url_tests]
     runs-on: ubuntu-latest
     if: always()
 
@@ -116,10 +142,12 @@ jobs:
       - name: Evaluate required checks
         run: |
           if [ "${{ needs.code_quality.result }}" != "success" ] || \
-             [ "${{ needs.tests.result }}" != "success" ]; then
+             [ "${{ needs.tests.result }}" != "success" ] || \
+             [ "${{ needs.lambda_presigned_url_tests.result }}" != "success" ]; then
             echo "❌ Required checks failed."
-            echo "  code_quality : ${{ needs.code_quality.result }}"
-            echo "  tests        : ${{ needs.tests.result }}"
+            echo "  code_quality               : ${{ needs.code_quality.result }}"
+            echo "  tests                      : ${{ needs.tests.result }}"
+            echo "  lambda_presigned_url_tests : ${{ needs.lambda_presigned_url_tests.result }}"
             exit 1
           fi
           echo "✅ All required checks passed."

--- a/lambda/presigned-url/index.mjs
+++ b/lambda/presigned-url/index.mjs
@@ -1,0 +1,71 @@
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import jwt from "jsonwebtoken";
+
+const s3 = new S3Client({ region: process.env.AWS_REGION });
+const ssm = new SSMClient({ region: process.env.AWS_REGION });
+const ALLOWED_TYPES = { "image/jpeg": "jpg", "image/png": "png", "image/webp": "webp" };
+
+// Lido uma vez no cold start e cacheado em memória entre invocações warm —
+// não bate no SSM a cada request.
+let jwtSecretPromise;
+function getJwtSecret() {
+  if (!jwtSecretPromise) {
+    jwtSecretPromise = ssm
+      .send(new GetParameterCommand({ Name: "/imm/production/JWT_SECRET", WithDecryption: true }))
+      .then((res) => res.Parameter.Value);
+  }
+  return jwtSecretPromise;
+}
+
+// Pura (sem AWS SDK) — testável isolada. Nunca confia em userId de fora:
+// deriva de um JWT verificado. Refresh token tem { type: "refresh" } no
+// payload (ver token.ts do imm-api) — só access token gera upload URL.
+export function verifyAccessToken(token, secret) {
+  const payload = jwt.verify(token, secret);
+  if (payload.type === "refresh") {
+    throw new Error("refresh token cannot be used here");
+  }
+  return payload.id; // mesmo campo que generateTokens() usa no imm-api
+}
+
+export const handler = async (event) => {
+  const authHeader = event.headers?.authorization ?? event.headers?.Authorization;
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  if (!token) {
+    return { statusCode: 401, body: JSON.stringify({ error: "Token ausente" }) };
+  }
+
+  let userId;
+  try {
+    const secret = await getJwtSecret();
+    userId = verifyAccessToken(token, secret);
+  } catch {
+    return { statusCode: 401, body: JSON.stringify({ error: "Token inválido ou expirado" }) };
+  }
+
+  const { contentType } = JSON.parse(event.body ?? "{}");
+  if (!ALLOWED_TYPES[contentType]) {
+    return { statusCode: 422, body: JSON.stringify({ error: "contentType (jpeg/png/webp) obrigatório" }) };
+  }
+
+  // key fixa por usuário — novo upload sobrescreve o antigo, sem órfão
+  const key = `avatars/${userId}.${ALLOWED_TYPES[contentType]}`;
+
+  const command = new PutObjectCommand({
+    Bucket: process.env.S3_AVATARS_BUCKET,
+    Key: key,
+    ContentType: contentType,
+  });
+
+  const signedUrl = await getSignedUrl(s3, command, { expiresIn: 300 }); // 5 min pra completar o upload
+  const publicUrl = `https://${process.env.CLOUDFRONT_DOMAIN}/${key}`;
+
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ signedUrl, publicUrl }),
+  };
+};

--- a/lambda/presigned-url/index.mjs
+++ b/lambda/presigned-url/index.mjs
@@ -3,18 +3,35 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
 import jwt from "jsonwebtoken";
 
-const s3 = new S3Client({ region: process.env.AWS_REGION });
+// WHEN_REQUIRED: sem isso, o SDK embute o checksum de um corpo VAZIO na URL
+// assinada (calculado antes do PUT real acontecer) — o upload real, com bytes
+// de verdade, sempre bate BadDigest contra esse checksum errado.
+const s3 = new S3Client({
+  region: process.env.AWS_REGION,
+  requestChecksumCalculation: "WHEN_REQUIRED",
+});
 const ssm = new SSMClient({ region: process.env.AWS_REGION });
-const ALLOWED_TYPES = { "image/jpeg": "jpg", "image/png": "png", "image/webp": "webp" };
+const ALLOWED_TYPES = new Map([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+]);
+const MAX_CONTENT_LENGTH = 5 * 1024 * 1024; // 5 MB — generoso pra foto de perfil
 
 // Lido uma vez no cold start e cacheado em memória entre invocações warm —
-// não bate no SSM a cada request.
+// não bate no SSM a cada request. Se a promise rejeitar, NÃO fica cacheada
+// (reset no catch) — um erro transitório do SSM não deve travar o container
+// inteiro em "sem segredo" pra sempre; a próxima invocação tenta de novo.
 let jwtSecretPromise;
 function getJwtSecret() {
   if (!jwtSecretPromise) {
     jwtSecretPromise = ssm
       .send(new GetParameterCommand({ Name: "/imm/production/JWT_SECRET", WithDecryption: true }))
-      .then((res) => res.Parameter.Value);
+      .then((res) => res.Parameter.Value)
+      .catch((err) => {
+        jwtSecretPromise = undefined;
+        throw err;
+      });
   }
   return jwtSecretPromise;
 }
@@ -23,49 +40,108 @@ function getJwtSecret() {
 // deriva de um JWT verificado. Refresh token tem { type: "refresh" } no
 // payload (ver token.ts do imm-api) — só access token gera upload URL.
 export function verifyAccessToken(token, secret) {
-  const payload = jwt.verify(token, secret);
+  const payload = jwt.verify(token, secret, { algorithms: ["HS256"] });
   if (payload.type === "refresh") {
     throw new Error("refresh token cannot be used here");
+  }
+  if (!payload.id) {
+    throw new Error("token missing subject");
   }
   return payload.id; // mesmo campo que generateTokens() usa no imm-api
 }
 
 export const handler = async (event) => {
-  const authHeader = event.headers?.authorization ?? event.headers?.Authorization;
+  const authHeader = event.headers?.authorization;
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
 
   if (!token) {
     return { statusCode: 401, body: JSON.stringify({ error: "Token ausente" }) };
   }
 
+  // Falha de infra (SSM fora do ar) é 503 + log — não é a mesma coisa que
+  // "usuário mandou token inválido", e sem log não dá pra distinguir os dois
+  // numa Function URL pública sem auth IAM.
+  let secret;
+  try {
+    secret = await getJwtSecret();
+  } catch (err) {
+    console.error("Failed to load JWT secret from SSM", err);
+    return { statusCode: 503, body: JSON.stringify({ error: "Serviço indisponível" }) };
+  }
+
   let userId;
   try {
-    const secret = await getJwtSecret();
     userId = verifyAccessToken(token, secret);
   } catch {
     return { statusCode: 401, body: JSON.stringify({ error: "Token inválido ou expirado" }) };
   }
 
-  const { contentType } = JSON.parse(event.body ?? "{}");
-  if (!ALLOWED_TYPES[contentType]) {
-    return { statusCode: 422, body: JSON.stringify({ error: "contentType (jpeg/png/webp) obrigatório" }) };
+  let body;
+  try {
+    body = JSON.parse(
+      event.isBase64Encoded
+        ? Buffer.from(event.body ?? "", "base64").toString("utf8")
+        : (event.body ?? "{}")
+    );
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: "Corpo da requisição inválido" }) };
+  }
+
+  const { contentType, contentLength } = body ?? {};
+  const ext = ALLOWED_TYPES.get(contentType);
+  if (!ext) {
+    return {
+      statusCode: 422,
+      body: JSON.stringify({ error: "contentType (jpeg/png/webp) obrigatório" }),
+    };
+  }
+  if (
+    !Number.isInteger(contentLength) ||
+    contentLength <= 0 ||
+    contentLength > MAX_CONTENT_LENGTH
+  ) {
+    return {
+      statusCode: 422,
+      body: JSON.stringify({
+        error: `contentLength deve ser entre 1 e ${MAX_CONTENT_LENGTH} bytes`,
+      }),
+    };
   }
 
   // key fixa por usuário — novo upload sobrescreve o antigo, sem órfão
-  const key = `avatars/${userId}.${ALLOWED_TYPES[contentType]}`;
+  const key = `avatars/${userId}.${ext}`;
 
   const command = new PutObjectCommand({
     Bucket: process.env.S3_AVATARS_BUCKET,
     Key: key,
     ContentType: contentType,
+    ContentLength: contentLength,
   });
 
-  const signedUrl = await getSignedUrl(s3, command, { expiresIn: 300 }); // 5 min pra completar o upload
+  let signedUrl;
+  try {
+    // content-type e content-length precisam entrar em signableHeaders — por
+    // padrão o presigner só assina "host", então sem isso o S3 aceitaria
+    // qualquer content-type/tamanho no PUT real, tornando a validação acima
+    // inútil (o browser pode mandar o header que quiser).
+    signedUrl = await getSignedUrl(s3, command, {
+      expiresIn: 300, // 5 min pra completar o upload
+      signableHeaders: new Set(["content-type", "content-length"]),
+    });
+  } catch (err) {
+    console.error("Failed to generate presigned URL", err);
+    return { statusCode: 500, body: JSON.stringify({ error: "Falha ao gerar URL de upload" }) };
+  }
+
   const publicUrl = `https://${process.env.CLOUDFRONT_DOMAIN}/${key}`;
 
   return {
     statusCode: 200,
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ signedUrl, publicUrl }),
+    body: JSON.stringify({
+      signedUrl,
+      publicUrl,
+      requiredHeaders: { "Content-Type": contentType, "Content-Length": contentLength },
+    }),
   };
 };

--- a/lambda/presigned-url/index.test.mjs
+++ b/lambda/presigned-url/index.test.mjs
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { verifyAccessToken } from "./index.mjs";
+
+const SECRET = "test-secret";
+
+test("valid access token returns the userId", () => {
+  const token = jwt.sign({ id: "user-1", email: "a@b.com" }, SECRET, { expiresIn: "1h" });
+  assert.equal(verifyAccessToken(token, SECRET), "user-1");
+});
+
+test("expired token is rejected", () => {
+  const token = jwt.sign({ id: "user-1" }, SECRET, { expiresIn: -1 });
+  assert.throws(() => verifyAccessToken(token, SECRET));
+});
+
+test("token signed with a different secret is rejected", () => {
+  const token = jwt.sign({ id: "user-1" }, "wrong-secret", { expiresIn: "1h" });
+  assert.throws(() => verifyAccessToken(token, SECRET));
+});
+
+test("refresh token cannot be used to get an upload URL", () => {
+  const token = jwt.sign({ id: "user-1", type: "refresh" }, SECRET, { expiresIn: "1h" });
+  assert.throws(() => verifyAccessToken(token, SECRET));
+});

--- a/lambda/presigned-url/index.test.mjs
+++ b/lambda/presigned-url/index.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import jwt from "jsonwebtoken";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { verifyAccessToken } from "./index.mjs";
 
 const SECRET = "test-secret";
@@ -23,4 +25,35 @@ test("token signed with a different secret is rejected", () => {
 test("refresh token cannot be used to get an upload URL", () => {
   const token = jwt.sign({ id: "user-1", type: "refresh" }, SECRET, { expiresIn: "1h" });
   assert.throws(() => verifyAccessToken(token, SECRET));
+});
+
+test("token without a subject (id) is rejected", () => {
+  const token = jwt.sign({ email: "a@b.com" }, SECRET, { expiresIn: "1h" });
+  assert.throws(() => verifyAccessToken(token, SECRET));
+});
+
+// Regressão dos dois bugs bloqueantes achados na revisão: o presigner tem
+// que assinar content-type/content-length (senão o upload real com bytes
+// de verdade sempre falha com BadDigest, e o S3 aceita qualquer tipo/tamanho
+// vindo do browser). Roda sem rede — getSignedUrl é cálculo local.
+test("presigned URL signs content-type and content-length, no checksum param", async () => {
+  const s3 = new S3Client({
+    region: "us-east-1",
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+  const command = new PutObjectCommand({
+    Bucket: "bucket",
+    Key: "avatars/user-1.png",
+    ContentType: "image/png",
+    ContentLength: 1024,
+  });
+  const url = await getSignedUrl(s3, command, {
+    expiresIn: 300,
+    signableHeaders: new Set(["content-type", "content-length"]),
+  });
+  const params = new URL(url).searchParams;
+
+  assert.equal(params.get("X-Amz-SignedHeaders"), "content-length;content-type;host");
+  assert.equal(params.has("x-amz-checksum-crc32"), false);
 });

--- a/lambda/presigned-url/package-lock.json
+++ b/lambda/presigned-url/package-lock.json
@@ -1,0 +1,594 @@
+{
+  "name": "imm-lambda-presigned-url",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "imm-lambda-presigned-url",
+      "version": "1.0.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1096.0",
+        "@aws-sdk/client-ssm": "^3.1096.0",
+        "@aws-sdk/s3-request-presigner": "^3.1096.0",
+        "jsonwebtoken": "^9.0.3"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.21.tgz",
+      "integrity": "sha512-AcYTunavv8dqm9u2pbq/gIlFERUo+jQDKKLZpYOgMLLytoAJ/qoyuhWj97FB7UzpMFVJNzMEUylzKK/s/05org==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1096.0.tgz",
+      "integrity": "sha512-sEx7KAEtkp1UqOoWQv2baM1rreClZG7o9YE8EfPvYpPBvGad1fQRG3sMHrOPMkIdZ9VjGRl25GiaG1MSeie2Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.21",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-node": "^3.972.73",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.67",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1096.0.tgz",
+      "integrity": "sha512-0XcirYRFHk1aWNqUy1QmQKqluZcAvWNAjVUo4izzMlb1bLg1vS8Cmsh2gfONhadBoGXyeSPbkDgWxZWVNXaXrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-node": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz",
+      "integrity": "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz",
+      "integrity": "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz",
+      "integrity": "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-env": "^3.972.62",
+        "@aws-sdk/credential-provider-http": "^3.972.64",
+        "@aws-sdk/credential-provider-login": "^3.972.69",
+        "@aws-sdk/credential-provider-process": "^3.972.62",
+        "@aws-sdk/credential-provider-sso": "^3.973.6",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz",
+      "integrity": "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.73.tgz",
+      "integrity": "sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.62",
+        "@aws-sdk/credential-provider-http": "^3.972.64",
+        "@aws-sdk/credential-provider-ini": "^3.973.7",
+        "@aws-sdk/credential-provider-process": "^3.972.62",
+        "@aws-sdk/credential-provider-sso": "^3.973.6",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz",
+      "integrity": "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz",
+      "integrity": "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/token-providers": "3.1096.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz",
+      "integrity": "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.67.tgz",
+      "integrity": "sha512-aB1ahF9z4J5r8YK1QodwNX/P8XSKBFtnjf7h72XCs0BP3rtThOiXeA3Lm+Z+8tiN9Iwl5otsGeHaXmQoQ5MVfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz",
+      "integrity": "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1096.0.tgz",
+      "integrity": "sha512-vyWoSQwoWLAr/rB06vstzOXLWFCrRvyTz5HQC0jwZ51oEe+GKCIvF671AHicUfiwiVjNZ257VponbCWmrzj0Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz",
+      "integrity": "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/lambda/presigned-url/package.json
+++ b/lambda/presigned-url/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "imm-lambda-presigned-url",
+  "version": "1.0.0",
+  "description": "Presigned S3 URL generator for avatar upload — imm-presigned-url Lambda",
+  "main": "index.mjs",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "UNLICENSED",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1096.0",
+    "@aws-sdk/client-ssm": "^3.1096.0",
+    "@aws-sdk/s3-request-presigner": "^3.1096.0",
+    "jsonwebtoken": "^9.0.3"
+  }
+}


### PR DESCRIPTION
## Summary
- `lambda/presigned-url/index.mjs` — handler real do `imm-presigned-url` (Function URL, role, CD já existem — só o código faltava)
- Nunca confia em `userId` vindo do body: deriva de um JWT verificado com o mesmo `JWT_SECRET` do `imm-api` (lido do SSM, cacheado entre invocações warm)
- `verifyAccessToken()` isolada como função pura (sem AWS SDK) especificamente pra ser testável sem mockar S3/SSM
- Rejeita refresh token (só access token gera upload URL) e content-type fora da allowlist (jpeg/png/webp)

## Test plan
- [x] `node --test` local: 4/4 passando (token válido, expirado, secret errado, refresh token)
- [ ] Merge → dispara `cd-lambda-presigned-url.yml` (#155) → confirmar deploy real via `aws lambda get-function --function-name imm-presigned-url --query Configuration.LastModified`
- [ ] Teste ponta a ponta pendente até o `imm-web` apontar pra Function URL (PR futura)