### PR TITLE
fix: relabel webm/mp4 audio as video mimeType for Gemini's inline audio input

### DIFF
--- a/src/core/ai/providers/gemini-transcription.ts
+++ b/src/core/ai/providers/gemini-transcription.ts
@@ -4,6 +4,21 @@ import type { TranscriptionProvider } from "../transcription.interface.js";
 
 const TIMEOUT_MS = 30_000;
 
+// Gemini's inline audio input only accepts wav/mp3/aiff/aac/ogg/flac — webm and
+// the mp4 container MediaRecorder produces (Chrome/Firefox and Safari/iOS,
+// respectively) aren't in that list and get rejected with 400 INVALID_ARGUMENT.
+// Both containers ARE accepted as video mimeTypes though, and Gemini processes
+// the audio track from video input same as from audio input — relabeling here
+// avoids needing a real transcode step.
+const GEMINI_MIME_TYPE_MAP: Record<string, string> = {
+  "audio/webm": "video/webm",
+  "audio/mp4": "video/mp4",
+};
+
+function toGeminiMimeType(mimeType: string): string {
+  return GEMINI_MIME_TYPE_MAP[mimeType] ?? mimeType;
+}
+
 type GeminiResponse = {
   candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
 };
@@ -18,7 +33,10 @@ async function callOnce(
   const requestBody = JSON.stringify({
     contents: [
       {
-        parts: [{ inlineData: { mimeType, data: audioBase64 } }, { text: prompt }],
+        parts: [
+          { inlineData: { mimeType: toGeminiMimeType(mimeType), data: audioBase64 } },
+          { text: prompt },
+        ],
       },
     ],
     generationConfig: {

--- a/tests/unit/gemini-transcription.test.ts
+++ b/tests/unit/gemini-transcription.test.ts
@@ -1,0 +1,41 @@
+import { GeminiTranscriptionProvider } from "@/core/ai/providers/gemini-transcription.js";
+
+function mockFetchOnce(responseBody: unknown, status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status < 300,
+    status,
+    json: () => Promise.resolve(responseBody),
+    text: () => Promise.resolve(JSON.stringify(responseBody)),
+  });
+}
+
+function getSentMimeType(fetchMock: jest.Mock): string {
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+  return body.contents[0].parts[0].inlineData.mimeType;
+}
+
+const geminiOkResponse = { candidates: [{ content: { parts: [{ text: "hello world" }] } }] };
+
+describe("GeminiTranscriptionProvider — mimeType mapping", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it.each([
+    ["audio/webm", "video/webm"],
+    ["audio/mp4", "video/mp4"],
+    ["audio/ogg", "audio/ogg"],
+  ])(
+    "sends %s to Gemini as %s (Gemini's inline audio input rejects webm/mp4 with 400)",
+    async (recordedMimeType, expectedGeminiMimeType) => {
+      const fetchMock = mockFetchOnce(geminiOkResponse);
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const provider = new GeminiTranscriptionProvider();
+      await provider.transcribe("ZmFrZQ==", recordedMimeType, "transcribe this", 500);
+
+      expect(getSentMimeType(fetchMock)).toBe(expectedGeminiMimeType);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
Journal/pronunciation audio transcription has been returning 500 in production since the audio-no-storage release — root cause: Gemini's inline audio input only accepts `wav/mp3/aiff/aac/ogg/flac` (confirmed against the official docs), and `audio/webm` (Chrome/Firefox) / `audio/mp4` (Safari/iOS) — exactly what `MediaRecorder` actually produces — both get rejected with `400 INVALID_ARGUMENT`.

Fix: relabel `audio/webm` → `video/webm` and `audio/mp4` → `video/mp4` only for the Gemini request. Both ARE accepted video mimeTypes, and Gemini documents that it processes the audio track from video input the same way — no real transcode step needed. `audio/ogg` (already Gemini-supported) passes through unchanged.

Scoped entirely inside `GeminiTranscriptionProvider` — the multipart validation/magic-byte checks upstream still see the real `audio/*` mimetype, only the outgoing Gemini request body changes.

## Test plan
- [x] New `tests/unit/gemini-transcription.test.ts` asserts the exact mimeType sent to Gemini for all 3 recorder outputs (`audio/webm`→`video/webm`, `audio/mp4`→`video/mp4`, `audio/ogg` unchanged)
- [x] `npm run lint`, `npm run typecheck`, `npm run test:unit` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Melhorada a compatibilidade da transcrição de áudio com o Gemini, ajustando automaticamente formatos como WebM e MP4 para os tipos aceitos pelo serviço.

* **Testes**
  * Adicionados testes para validar o envio correto dos tipos MIME em diferentes formatos de áudio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->