### PR TITLE
feat: load DATABASE_URL/GEMINI_API_KEY from SSM in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1098.0",
+        "@aws-sdk/client-ssm": "^3.1098.0",
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
         "@fastify/helmet": "^13.0.2",
@@ -66,6 +67,25 @@
       "version": "3.1098.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1098.0.tgz",
       "integrity": "sha512-AgG54/+FtgMT/C9vHqPklNkVimun0DX3bm9CtX7V9OPfFWweU303hpfsYcHnOYhkRKzHq7mnke1Z1+Eva3UnjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1098.0.tgz",
+      "integrity": "sha512-PS1R2Py6gn6vQFcDKxzRMDrExL4V8mfxPBQpsUgZRfC1WTveR5pnm+UEWWCMqus9RQpO7lHD+HMm6YTtOb20bQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.977.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "ISC",
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1098.0",
+    "@aws-sdk/client-ssm": "^3.1098.0",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",

--- a/src/core/config/load-secrets.ts
+++ b/src/core/config/load-secrets.ts
@@ -1,0 +1,29 @@
+import { SSMClient, GetParametersCommand } from "@aws-sdk/client-ssm";
+import { logger } from "./logger.js";
+
+const SSM_SECRET_KEYS = ["DATABASE_URL", "GEMINI_API_KEY"] as const;
+
+// Only in production — local/test keep reading straight from .env. Falls back
+// to whatever's already in process.env (from .env) on any SSM failure, so a
+// missing/broken permission degrades to the old behavior instead of crashing
+// the boot — same reasoning as the presigned-url Lambda's JWT_SECRET fetch.
+// Must run (and be awaited) before env.js is imported, since that module
+// parses process.env synchronously at import time.
+export async function loadSecretsFromSsm(): Promise<void> {
+  if (process.env.NODE_ENV !== "production") return;
+  try {
+    const ssm = new SSMClient({ region: process.env.AWS_REGION ?? "us-east-1" });
+    const { Parameters } = await ssm.send(
+      new GetParametersCommand({
+        Names: SSM_SECRET_KEYS.map((key) => `/imm/production/${key}`),
+        WithDecryption: true,
+      })
+    );
+    for (const param of Parameters ?? []) {
+      const key = param.Name?.split("/").pop();
+      if (key && param.Value) process.env[key] = param.Value;
+    }
+  } catch (err) {
+    logger.warn({ err }, "Failed to load secrets from SSM, falling back to .env");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { env } from "./core/config/env.js";
-import { buildApp } from "./app.js";
+import { loadSecretsFromSsm } from "./core/config/load-secrets.js";
 import { logger } from "./core/config/logger.js";
 import { setTimeout } from "node:timers";
 
@@ -7,6 +6,13 @@ const SHUTDOWN_TIMEOUT = 10_000;
 
 const start = async () => {
   try {
+    // Must resolve before env.js is imported below — it parses process.env
+    // synchronously at import time, so SSM-sourced secrets need to already
+    // be in process.env by then.
+    await loadSecretsFromSsm();
+    const { env } = await import("./core/config/env.js");
+    const { buildApp } = await import("./app.js");
+
     const fastify = await buildApp();
 
     const shutdown = async () => {

--- a/tests/unit/load-secrets.test.ts
+++ b/tests/unit/load-secrets.test.ts
@@ -1,0 +1,56 @@
+import { loadSecretsFromSsm } from "@/core/config/load-secrets.js";
+
+const mockSsmSend = jest.fn();
+
+jest.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: jest.fn().mockImplementation(() => ({ send: mockSsmSend })),
+  GetParametersCommand: jest.fn((input) => input),
+}));
+
+describe("loadSecretsFromSsm", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockSsmSend.mockReset();
+    delete process.env.DATABASE_URL;
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("does nothing outside production", async () => {
+    process.env.NODE_ENV = "test";
+
+    await loadSecretsFromSsm();
+
+    expect(mockSsmSend).not.toHaveBeenCalled();
+    expect(process.env.DATABASE_URL).toBeUndefined();
+  });
+
+  it("populates process.env from the SSM parameters in production", async () => {
+    process.env.NODE_ENV = "production";
+    mockSsmSend.mockResolvedValue({
+      Parameters: [
+        { Name: "/imm/production/DATABASE_URL", Value: "postgresql://from-ssm" },
+        { Name: "/imm/production/GEMINI_API_KEY", Value: "gemini-key-from-ssm" },
+      ],
+    });
+
+    await loadSecretsFromSsm();
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://from-ssm");
+    expect(process.env.GEMINI_API_KEY).toBe("gemini-key-from-ssm");
+  });
+
+  it("falls back to whatever is already in process.env when SSM fails", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.DATABASE_URL = "postgresql://from-dotenv";
+    mockSsmSend.mockRejectedValue(new Error("AccessDenied"));
+
+    await expect(loadSecretsFromSsm()).resolves.toBeUndefined();
+
+    expect(process.env.DATABASE_URL).toBe("postgresql://from-dotenv");
+  });
+});


### PR DESCRIPTION
## Summary
Implements the pending "Checklist SSM" item — `imm-api` now fetches `DATABASE_URL` and `GEMINI_API_KEY` from SSM Parameter Store (`/imm/production/*`, SecureString) in production, instead of only reading them from the EC2 `.env` file. `JWT_SECRET` already worked this way for the presigned-url Lambda; this brings `imm-api` itself in line.

- Only runs when `NODE_ENV=production` — local/test unaffected.
- Falls back to whatever's already in `process.env` (from `.env`) if the SSM call fails for any reason — a missing/broken IAM permission degrades gracefully instead of crashing boot.
- Deliberately **not** inside `env.ts`: a top-level `await` there broke ts-jest's module compilation (every test suite failed with `TS1378`). Moved to a dedicated `load-secrets.ts`, awaited explicitly in `index.ts` before dynamically importing `env.js`/`app.js` — `env.ts` itself stays fully synchronous, zero existing tests changed.

IAM side (`imm-ec2-policy`) already has `ssm:GetParameter`/`GetParametersByPath` scoped to `/imm/*`; this PR's prerequisite was adding `kms:Decrypt` scoped to the same KMS key the Lambda already uses — applied live and confirmed via `iam simulate-principal-policy` (both `ssm:GetParameter` and `kms:Decrypt` return `allowed` against the real resource ARNs).

**Not included** (separate step, do after this deploys and is confirmed working): removing `DATABASE_URL`/`GEMINI_API_KEY` from the EC2's physical `.env` file.

## Test plan
- [x] New `tests/unit/load-secrets.test.ts`: no-op outside production, populates `process.env` from SSM in production, falls back to existing `process.env` on SSM failure
- [x] `npm run lint`, `npm run typecheck`, `npm run test:unit` all green (260 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Segredos de produção agora podem ser carregados automaticamente do AWS SSM.
  * O sistema mantém os valores configurados anteriormente caso o serviço de segredos esteja indisponível.

* **Correções**
  * Garante que as configurações sejam carregadas após a obtenção dos segredos, evitando falhas na inicialização.

* **Testes**
  * Adicionados testes para validar carregamento, fallback e comportamento fora de produção.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->