### PR TITLE
fix: remove invalid Gemini thinkingConfig, pin to gemini-3.5-flash-lite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ EMAIL_PROVIDER=ses
 # Gemini AI (required if AI_PROVIDER or TRANSCRIPTION_PROVIDER includes "gemini")
 # Get your key at: https://aistudio.google.com/apikey
 GEMINI_API_KEY=your-gemini-api-key-from-aistudio
-GEMINI_API_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent
+GEMINI_API_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent
 
 # Supabase Storage (required if STORAGE_PROVIDER CSV includes "supabase")
 # Get your credentials at: https://supabase.com/dashboard

--- a/src/core/ai/providers/gemini-text.ts
+++ b/src/core/ai/providers/gemini-text.ts
@@ -19,7 +19,6 @@ async function callOnce(
     generationConfig: {
       temperature: options?.temperature ?? 0.7,
       maxOutputTokens,
-      thinkingConfig: { thinkingBudget: 0 },
       ...(options?.responseSchema
         ? {
             responseMimeType: "application/json",

--- a/src/core/ai/providers/gemini-transcription.ts
+++ b/src/core/ai/providers/gemini-transcription.ts
@@ -24,7 +24,6 @@ async function callOnce(
     generationConfig: {
       temperature: 0,
       maxOutputTokens,
-      thinkingConfig: { thinkingBudget: 0 },
     },
   });
 

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -62,7 +62,7 @@ export const envSchema = z
     GEMINI_API_URL: z
       .url()
       .default(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent"
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent"
       ),
 
     // Supabase Storage (required if STORAGE_PROVIDER includes "supabase")


### PR DESCRIPTION
## Summary
- `thinkingConfig.thinkingBudget: 0` isn't supported by the Gemini model in use — every text/audio call was failing with a 400 "invalid argument". Reproduced in isolation via curl (both audio and plain-text requests) and confirmed against the official Gemini docs: the model isn't in the thinking-capable list, and the current param name is `thinking_level`, not `thinkingBudget`. Removed from both `gemini-transcription.ts` and `gemini-text.ts` (same broken pattern in both).
- Default `GEMINI_API_URL` swapped from `gemini-flash-latest` (an auto-swapping alias — silently follows Google's newest release, no code change on our end) to `gemini-3.5-flash-lite`. `gemini-2.5-flash-lite` was tried first but returns a 404 "no longer available to new users" on this account; `gemini-3.5-flash-lite` tested clean for text + audio and gives double the rate limit of what was effectively in use.

## Test plan
- [x] `npm run lint` / `npm run typecheck` clean
- [x] `npm run test:unit` (257/257) + `npm run test:integration` (2/2)
- [x] Verified empirically via direct curl against the Gemini API (text + audio, with/without thinkingConfig) before applying the fix
- [x] Verified locally end-to-end (frontend + backend) — audio transcription works
- [ ] After merge: production EC2 `.env`'s `GEMINI_API_URL` needs updating manually (not part of this PR, `.env` isn't versioned) + `pm2 restart imm-api` if not covered by the deploy that follows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Atualizada a configuração padrão do Gemini para utilizar o modelo `gemini-3.5-flash-lite`.
  * Simplificada a geração de respostas e transcrições, removendo uma configuração opcional de processamento avançado.
  * Mantidos os mecanismos existentes de validação, limites de tempo e tratamento de erros nas chamadas ao serviço.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->