### PR TITLE
feat: load JWT_SECRET from SSM in production

### DIFF
--- a/src/core/config/load-secrets.ts
+++ b/src/core/config/load-secrets.ts
@@ -1,7 +1,7 @@
 import { SSMClient, GetParametersCommand } from "@aws-sdk/client-ssm";
 import { logger } from "./logger.js";
 
-const SSM_SECRET_KEYS = ["DATABASE_URL", "GEMINI_API_KEY"] as const;
+const SSM_SECRET_KEYS = ["DATABASE_URL", "GEMINI_API_KEY", "JWT_SECRET"] as const;
 
 // Only in production — local/test keep reading straight from .env. Falls back
 // to whatever's already in process.env (from .env) on any SSM failure, so a

--- a/tests/unit/load-secrets.test.ts
+++ b/tests/unit/load-secrets.test.ts
@@ -14,6 +14,7 @@ describe("loadSecretsFromSsm", () => {
     mockSsmSend.mockReset();
     delete process.env.DATABASE_URL;
     delete process.env.GEMINI_API_KEY;
+    delete process.env.JWT_SECRET;
   });
 
   afterEach(() => {
@@ -35,6 +36,7 @@ describe("loadSecretsFromSsm", () => {
       Parameters: [
         { Name: "/imm/production/DATABASE_URL", Value: "postgresql://from-ssm" },
         { Name: "/imm/production/GEMINI_API_KEY", Value: "gemini-key-from-ssm" },
+        { Name: "/imm/production/JWT_SECRET", Value: "jwt-secret-from-ssm" },
       ],
     });
 
@@ -42,6 +44,7 @@ describe("loadSecretsFromSsm", () => {
 
     expect(process.env.DATABASE_URL).toBe("postgresql://from-ssm");
     expect(process.env.GEMINI_API_KEY).toBe("gemini-key-from-ssm");
+    expect(process.env.JWT_SECRET).toBe("jwt-secret-from-ssm");
   });
 
   it("falls back to whatever is already in process.env when SSM fails", async () => {

--- a/tests/unit/load-secrets.test.ts
+++ b/tests/unit/load-secrets.test.ts
@@ -42,6 +42,14 @@ describe("loadSecretsFromSsm", () => {
 
     await loadSecretsFromSsm();
 
+    expect(mockSsmSend).toHaveBeenCalledWith({
+      Names: [
+        "/imm/production/DATABASE_URL",
+        "/imm/production/GEMINI_API_KEY",
+        "/imm/production/JWT_SECRET",
+      ],
+      WithDecryption: true,
+    });
     expect(process.env.DATABASE_URL).toBe("postgresql://from-ssm");
     expect(process.env.GEMINI_API_KEY).toBe("gemini-key-from-ssm");
     expect(process.env.JWT_SECRET).toBe("jwt-secret-from-ssm");


### PR DESCRIPTION
## Summary
- `imm-api` now reads `JWT_SECRET` from SSM (`/imm/production/JWT_SECRET`) in production, same as `DATABASE_URL`/`GEMINI_API_KEY` already do — falls back to `.env` on any SSM failure instead of crashing boot.
- The parameter already existed (the presigned-url Lambda already reads it) — this was the one gap flagged in this session's Módulo 9 security audit: the most security-critical secret (auth) was the only one of the three still `.env`-only.

## Test plan
- [x] `npm run lint` / `npm run typecheck` clean
- [x] `load-secrets.test.ts` updated to cover `JWT_SECRET` alongside the other two keys
- [x] Full suite green: 257 unit + 2 integration tests
- [ ] After merge/deploy: confirm no SSM-failure warning in pm2 logs (same check used for the original SSM PR #163)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * O segredo `JWT_SECRET` passou a ser carregado corretamente das configurações de produção.
  * O valor é disponibilizado automaticamente para a aplicação durante a execução.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->