### PR TITLE
fix: stop requiring Supabase secrets to boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,13 @@ CORS_ORIGIN=http://localhost:3000
 LOG_LEVEL=info
 
 # Database
+# In production, this is loaded from SSM (/imm/production/DATABASE_URL) at boot —
+# the value below only matters for local dev, or as a fallback if SSM fails.
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/inside_my_mind_dev
 
 # JWT Authentication
+# In production, JWT_SECRET is loaded from SSM (/imm/production/JWT_SECRET) at boot —
+# same fallback behavior as DATABASE_URL above.
 JWT_SECRET=your-super-secret-jwt-key-change-in-production-min-32-chars
 JWT_ACCESS_EXPIRES=15m
 JWT_REFRESH_EXPIRES=7d
@@ -24,11 +28,14 @@ TRANSCRIPTION_PROVIDER=gemini
 EMAIL_PROVIDER=ses
 
 # Gemini AI (required if AI_PROVIDER or TRANSCRIPTION_PROVIDER includes "gemini")
+# In production, GEMINI_API_KEY is also loaded from SSM (/imm/production/GEMINI_API_KEY) at boot.
 # Get your key at: https://aistudio.google.com/apikey
 GEMINI_API_KEY=your-gemini-api-key-from-aistudio
 GEMINI_API_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent
 
-# Supabase Storage (required if STORAGE_PROVIDER CSV includes "supabase")
+# Supabase Storage — optional. Avatar upload bypasses imm-api entirely now
+# (frontend talks straight to a presigned-url Lambda); these only matter if
+# you're exercising the legacy /users/me/avatar-upload-url fallback route.
 # Get your credentials at: https://supabase.com/dashboard
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 SUPABASE_STORAGE_BUCKET=avatars

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -65,7 +65,10 @@ export const envSchema = z
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent"
       ),
 
-    // Supabase Storage (required if STORAGE_PROVIDER includes "supabase")
+    // Supabase Storage — optional. Avatar upload bypasses imm-api entirely
+    // now (frontend talks straight to the presigned-url Lambda); this route
+    // is kept only as a fallback to revert to Supabase later, so it must
+    // not force these secrets to exist just to boot.
     SUPABASE_URL: z.url().optional(),
     SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
     SUPABASE_STORAGE_BUCKET: z.string().default("avatars"),
@@ -91,26 +94,6 @@ export const envSchema = z
         message:
           "GEMINI_API_KEY is required when AI_PROVIDER or TRANSCRIPTION_PROVIDER includes gemini",
         path: ["GEMINI_API_KEY"],
-      });
-    }
-
-    const usesSupabase = data.STORAGE_PROVIDER.split(",")
-      .map((p) => p.trim())
-      .includes("supabase");
-
-    if (usesSupabase && !data.SUPABASE_URL) {
-      ctx.addIssue({
-        code: "custom",
-        message: "SUPABASE_URL is required when STORAGE_PROVIDER=supabase",
-        path: ["SUPABASE_URL"],
-      });
-    }
-
-    if (usesSupabase && !data.SUPABASE_SERVICE_ROLE_KEY) {
-      ctx.addIssue({
-        code: "custom",
-        message: "SUPABASE_SERVICE_ROLE_KEY is required when STORAGE_PROVIDER=supabase",
-        path: ["SUPABASE_SERVICE_ROLE_KEY"],
       });
     }
 

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -34,3 +34,15 @@ describe("envSchema — EMAIL_PROVIDER conditional validation", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("envSchema — Supabase is optional", () => {
+  it("boots without SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY", () => {
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ...envWithoutSupabase } = baseEnv;
+    void SUPABASE_URL;
+    void SUPABASE_SERVICE_ROLE_KEY;
+
+    const result = envSchema.safeParse(envWithoutSupabase);
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Avatar upload bypasses `imm-api` entirely now (frontend talks straight to the presigned-url Lambda). The old `/users/me/avatar-upload-url` route + Supabase storage provider are still there and working — kept deliberately as a fallback to revert to Supabase later, not dead code.
- But the env schema still required `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` just to boot, even though nothing calls that route today. Removed the `STORAGE_PROVIDER=supabase` conditional requirement — both fields were already `.optional()` at the field level, this only drops the `superRefine` check forcing them.
- Route/controller/factory/provider code is untouched — if `/users/me/avatar-upload-url` is ever called without these configured, it fails at that call site, not at boot. Reversibility to Supabase stays intact.

## Test plan
- [x] `npm run lint` / `npm run typecheck` clean
- [x] New test: `envSchema` boots successfully without `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`
- [x] Full suite green: 258 unit + 2 integration tests