### PR TITLE
fix: load .env before checking NODE_ENV, so SSM actually runs in prod

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
+import { config } from "dotenv";
+import { existsSync } from "fs";
+import { resolve } from "path";
 import { loadSecretsFromSsm } from "./core/config/load-secrets.js";
 import { logger } from "./core/config/logger.js";
 import { setTimeout } from "node:timers";
+
+// Must run before loadSecretsFromSsm() reads process.env.NODE_ENV — that's
+// otherwise unset until env.ts's own dotenv call, which happens after.
+const envPath = resolve(process.cwd(), ".env");
+if (existsSync(envPath)) {
+  config({ path: envPath, quiet: true });
+}
 
 const SHUTDOWN_TIMEOUT = 10_000;
 


### PR DESCRIPTION
## Summary

`loadSecretsFromSsm()` checks `process.env.NODE_ENV` to decide whether to call SSM at all — but nothing had loaded `.env` into `process.env` yet at that point. `dotenv.config()` only ran inside `env.ts`, imported **after** `loadSecretsFromSsm()` resolves. So `NODE_ENV` was `undefined` every single time the guard ran, the function returned early, and SSM never actually got called in production since it was introduced (#163).

Nobody noticed because `.env` always had working values as a fallback, and a skipped SSM fetch looks identical to a successful one — neither logs anything on its own.

**Confirmed live today**: pulling `JWT_SECRET`/`DATABASE_URL`/`GEMINI_API_KEY` out of `.env` (should've been safe, since SSM was supposed to be the real source) took prod down in a crash loop. Debug instrumentation on the running instance showed `NODE_ENV` as literally `undefined` inside `loadSecretsFromSsm()`. Manually exporting `NODE_ENV=production` and restarting confirmed the fix works — SSM returned all 3 parameters correctly once the guard could see the right value.

**Fix**: load `.env` at the very top of `index.ts`, before anything else runs. `env.ts` keeps its own `dotenv` call too (needed when it's imported directly, e.g. tests) — harmless duplicate, `dotenv` doesn't override a key already in `process.env`.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run build` clean
- [x] Full suite green: 258 unit + 2 integration tests
- [x] **Verified live in production**: manually applied the equivalent fix (exporting `NODE_ENV` before restart) on the running EC2 instance — SSM fetch succeeded, all 3 secrets loaded, health check back to 200
- [ ] After merge/deploy: confirm no `Invalid environment variables` errors in pm2 logs, confirm `.env` no longer needs `DATABASE_URL`/`GEMINI_API_KEY`/`JWT_SECRET` as a safety net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * O carregamento de configurações locais agora ocorre automaticamente quando o arquivo `.env` está disponível.
  * As configurações são carregadas antes da inicialização do aplicativo, garantindo acesso consistente aos valores definidos no ambiente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->