### PR TITLE
release: sync main with develop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
+import { config } from "dotenv";
+import { existsSync } from "fs";
+import { resolve } from "path";
 import { loadSecretsFromSsm } from "./core/config/load-secrets.js";
 import { logger } from "./core/config/logger.js";
 import { setTimeout } from "node:timers";
+
+// Must run before loadSecretsFromSsm() reads process.env.NODE_ENV — that's
+// otherwise unset until env.ts's own dotenv call, which happens after.
+const envPath = resolve(process.cwd(), ".env");
+if (existsSync(envPath)) {
+  config({ path: envPath, quiet: true });
+}
 
 const SHUTDOWN_TIMEOUT = 10_000;
 


### PR DESCRIPTION
## Summary
- #171 stop requiring Supabase secrets to boot
- #172 fix: load .env before checking NODE_ENV, so SSM actually runs in prod — real production incident fix, root-caused and verified live today

## Test plan
- [x] Already tested/merged into develop with green CI (lint, typecheck, build, 258 unit + 2 integration tests)
- [x] #172's fix already manually verified live in production (equivalent fix applied by hand during the incident, confirmed working before this PR)
- [ ] Merge with `--merge` (not squash) — keeps the develop/main ancestry link intact